### PR TITLE
Increase timeout for waiting worker nodes to come up

### DIFF
--- a/test/e2e/data/config.yaml
+++ b/test/e2e/data/config.yaml
@@ -118,7 +118,7 @@ intervals:
   # [all] wait for cluster, control plane nodes, worker nodes to come up
   default/wait-cluster: ["1m", "10s"]
   default/wait-control-plane: ["5m", "10s"]
-  default/wait-worker-nodes: ["3m", "10s"]
+  default/wait-worker-nodes: ["5m", "10s"]
   default/wait-delete-cluster: ["3m", "10s"]
 
   # [conformance] override waiting for control plane nodes, worker nodes to come up


### PR DESCRIPTION
### Summary

The `QuickStart KVM` test flakes a bit and times out with the current 3 minutes, so increase that to 5 minutes 