### PR TITLE
Add `image-builder` utility

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,48 @@
+name: Build Images
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        required: true
+        description: Kubernetes version, e.g. "v1.33.0"
+        type: string
+
+jobs:
+  build:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+        # amd64 images
+        - { infrastructure: incus,  type: container,        runner: ubuntu-24.04 }
+        - { infrastructure: incus,  type: virtual-machine,  runner: ubuntu-24.04 }
+        - { infrastructure: lxd,    type: virtual-machine,  runner: ubuntu-24.04 }
+
+        # arm64 images
+        - { infrastructure: incus,  type: container,        runner: ubuntu-24.04-arm }
+        # - { infrastructure: incus,  type: virtual-machine,  runner: ubuntu-24.04-arm }    # arm64 runners do not support kvm
+        # - { infrastructure: lxd,    type: virtual-machine,  runner: ubuntu-24.04-arm }    # arm64 runners do not support kvm
+    runs-on: ${{ matrix.runner }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Setup infrastructure
+        run: |
+          ./hack/scripts/ci/setup-${{ matrix.infrastructure }}.sh
+
+      - name: Build image
+        run: |
+          go run ./cmd/image-builder --v=4 --kubernetes-version ${{ inputs.version }} --instance-type=${{ matrix.type }} --output image.tar.gz
+
+      - name: Upload image
+        uses: actions/upload-artifact@v4
+        with:
+          name: image-${{ matrix.infrastructure }}-${{ matrix.type }}-${{ matrix.runner }}
+          path: image.tar.gz

--- a/.github/workflows/build-kubeadm-images.yml
+++ b/.github/workflows/build-kubeadm-images.yml
@@ -1,4 +1,4 @@
-name: Build Images
+name: Build Kubeadm Images
 
 on:
   workflow_dispatch:
@@ -7,6 +7,8 @@ on:
         required: true
         description: Kubernetes version, e.g. "v1.33.0"
         type: string
+  push:
+    branches: [feat/cmd-image-builder]
 
 jobs:
   build:
@@ -15,15 +17,15 @@ jobs:
       matrix:
         include:
         # amd64 images
-        - { infrastructure: incus,  type: container,        runner: ubuntu-24.04 }
-        - { infrastructure: incus,  type: virtual-machine,  runner: ubuntu-24.04 }
-        - { infrastructure: lxd,    type: virtual-machine,  runner: ubuntu-24.04 }
+        - { infrastructure: incus,  type: container,        arch: amd64 }
+        - { infrastructure: incus,  type: virtual-machine,  arch: amd64 }
+        - { infrastructure: lxd,    type: virtual-machine,  arch: amd64 }
 
         # arm64 images
-        - { infrastructure: incus,  type: container,        runner: ubuntu-24.04-arm }
-        # - { infrastructure: incus,  type: virtual-machine,  runner: ubuntu-24.04-arm }    # arm64 runners do not support kvm
-        # - { infrastructure: lxd,    type: virtual-machine,  runner: ubuntu-24.04-arm }    # arm64 runners do not support kvm
-    runs-on: ${{ matrix.runner }}
+        - { infrastructure: incus,  type: container,        arch: arm64 }
+        # - { infrastructure: incus,  type: virtual-machine,  arch: arm64 }    # arm64 runners do not support kvm
+        # - { infrastructure: lxd,    type: virtual-machine,  arch: arm64 }    # arm64 runners do not support kvm
+    runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -39,7 +41,7 @@ jobs:
 
       - name: Build image
         run: |
-          go run ./cmd/image-builder --v=4 --kubernetes-version ${{ inputs.version }} --instance-type=${{ matrix.type }} --output image.tar.gz
+          go run ./cmd/image-builder --v=4 --kubernetes-version v1.33.0 --instance-type=${{ matrix.type }} --output image.tar.gz
 
       - name: Upload image
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-kubeadm-images.yml
+++ b/.github/workflows/build-kubeadm-images.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Build image
         run: |
-          go run ./cmd/image-builder kubeadm --v=4 --kubernetes-version v1.33.0 --instance-type=${{ matrix.type }} --output image.tar.gz
+          go run ./cmd/image-builder kubeadm --v=4 --kubernetes-version ${{ inputs.version }} --instance-type=${{ matrix.type }} --output image.tar.gz
 
       - name: Upload image
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build-kubeadm-images.yml
+++ b/.github/workflows/build-kubeadm-images.yml
@@ -7,8 +7,6 @@ on:
         required: true
         description: Kubernetes version, e.g. "v1.33.0"
         type: string
-  push:
-    branches: [feat/cmd-image-builder]
 
 jobs:
   build:
@@ -46,5 +44,5 @@ jobs:
       - name: Upload image
         uses: actions/upload-artifact@v4
         with:
-          name: image-${{ matrix.infrastructure }}-${{ matrix.type }}-${{ matrix.runner }}
+          name: kubeadm-${{ inputs.version }}-${{ matrix.infrastructure }}-${{ matrix.type }}-${{ matrix.arch }}
           path: image.tar.gz

--- a/.github/workflows/build-kubeadm-images.yml
+++ b/.github/workflows/build-kubeadm-images.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Build image
         run: |
-          go run ./cmd/image-builder --v=4 --kubernetes-version v1.33.0 --instance-type=${{ matrix.type }} --output image.tar.gz
+          go run ./cmd/image-builder kubeadm --v=4 --kubernetes-version v1.33.0 --instance-type=${{ matrix.type }} --output image.tar.gz
 
       - name: Upload image
         uses: actions/upload-artifact@v4

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,10 @@ issues:
     - path: "api/*"
       linters:
         - lll
+    - path: "cmd/*"
+      linters:
+        - lll
+        - goconst
     - path: "internal/*"
       linters:
         - dupl

--- a/Makefile
+++ b/Makefile
@@ -233,12 +233,17 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 ENVTEST ?= $(LOCALBIN)/setup-envtest
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 GINKGO = $(LOCALBIN)/ginkgo
+IMAGE_BUILDER = $(LOCALBIN)/image-builder
 
 ## Tool Versions
 KUSTOMIZE_VERSION ?= v5.5.0
 CONTROLLER_TOOLS_VERSION ?= v0.16.4
 ENVTEST_VERSION ?= release-0.19
 GOLANGCI_LINT_VERSION ?= v1.61.0
+
+.PHONY: image-builder
+image-builder: $(LOCALBIN)
+	go build -o $(IMAGE_BUILDER) ./cmd/image-builder
 
 .PHONY: kustomize
 kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.

--- a/cmd/image-builder/command_haproxy.go
+++ b/cmd/image-builder/command_haproxy.go
@@ -25,15 +25,15 @@ var (
 			).Info("Building haproxy image")
 
 			return runStages(
-				&createInstanceStage{},
-				&preRunCommandsStage{},
-				&installHaproxyStage{},
-				&postRunCommandsStage{},
-				&cleanupInstanceStage{},
-				&stopInstanceStage{},
-				&publishHaproxyImageStage{},
-				&exportImageStage{},
-				&removeInstanceStage{},
+				&stageCreateInstance{},
+				&stagePreRunCommands{},
+				&stageInstallHaproxy{},
+				&stagePostRunCommands{},
+				&stageCleanupInstance{},
+				&stageStopInstance{},
+				&stagePublishHaproxyImage{},
+				&stageExportImage{},
+				&stageRemoveInstance{},
 			)
 		},
 	}

--- a/cmd/image-builder/command_haproxy.go
+++ b/cmd/image-builder/command_haproxy.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var (
+	haproxyCmd = &cobra.Command{
+		Use:          "haproxy",
+		GroupID:      "build",
+		Short:        "Build haproxy images for cluster-api-provider-incus",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if cfg.imageAlias == "" {
+				cfg.imageAlias = fmt.Sprintf("haproxy-u%s", cfg.ubuntuVersion)
+			}
+
+			log.FromContext(gCtx).WithValues(
+				"ubuntu-version", cfg.ubuntuVersion,
+				"instance-type", cfg.instanceType,
+				"image-alias", cfg.imageAlias,
+			).Info("Building haproxy image")
+
+			return runStages(
+				&createInstanceStage{},
+				&preRunCommandsStage{},
+				&installHaproxyStage{},
+				&postRunCommandsStage{},
+				&cleanupInstanceStage{},
+				&stopInstanceStage{},
+				&publishHaproxyImageStage{},
+				&exportImageStage{},
+				&removeInstanceStage{},
+			)
+		},
+	}
+)

--- a/cmd/image-builder/command_kubeadm.go
+++ b/cmd/image-builder/command_kubeadm.go
@@ -31,17 +31,17 @@ var (
 			).Info("Building kubeadm image")
 
 			return runStages(
-				&createInstanceStage{},
-				&preRunCommandsStage{},
-				&installKubeadmStage{},
-				&pullExtraImagesStage{},
-				&generateManifestStage{},
-				&postRunCommandsStage{},
-				&cleanupInstanceStage{},
-				&stopInstanceStage{},
-				&publishKubeadmImageStage{},
-				&exportImageStage{},
-				&removeInstanceStage{},
+				&stageCreateInstance{},
+				&stagePreRunCommands{},
+				&stageInstallKubeadm{},
+				&stagePullExtraImages{},
+				&stageGenerateManifest{},
+				&stagePostRunCommands{},
+				&stageCleanupInstance{},
+				&stageStopInstance{},
+				&stagePublishKubeadmImage{},
+				&stageExportImage{},
+				&stageRemoveInstance{},
 			)
 		},
 	}

--- a/cmd/image-builder/command_kubeadm.go
+++ b/cmd/image-builder/command_kubeadm.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/blang/semver/v4"
+	"github.com/spf13/cobra"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+var (
+	kubeadmCmd = &cobra.Command{
+		Use:          "kubeadm",
+		GroupID:      "build",
+		Short:        "Build kubeadm images for cluster-api-provider-incus",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if _, err := semver.ParseTolerant(kubeadmCfg.kubernetesVersion); err != nil {
+				return fmt.Errorf("--kubernetes-version %q is not valid semver: %w", kubeadmCfg.kubernetesVersion, err)
+			}
+
+			if cfg.imageAlias == "" {
+				cfg.imageAlias = fmt.Sprintf("kubeadm-%s-u%s-%s", kubeadmCfg.kubernetesVersion, cfg.ubuntuVersion, cfg.instanceType)
+			}
+
+			log.FromContext(gCtx).WithValues(
+				"kubernetes-version", kubeadmCfg.kubernetesVersion,
+				"ubuntu-version", cfg.ubuntuVersion,
+				"instance-type", cfg.instanceType,
+				"image-alias", cfg.imageAlias,
+			).Info("Building kubeadm image")
+
+			return runStages(
+				&createInstanceStage{},
+				&preRunCommandsStage{},
+				&installKubeadmStage{},
+				&pullExtraImagesStage{},
+				&generateManifestStage{},
+				&postRunCommandsStage{},
+				&cleanupInstanceStage{},
+				&stopInstanceStage{},
+				&publishKubeadmImageStage{},
+				&exportImageStage{},
+				&removeInstanceStage{},
+			)
+		},
+	}
+)
+
+func init() {
+	kubeadmCmd.Flags().StringVar(&kubeadmCfg.kubernetesVersion, "kubernetes-version", "",
+		"Kubernetes version to create image for")
+
+	kubeadmCmd.Flags().StringSliceVar(&kubeadmCfg.pullExtraImages, "pull-extra-images", defaultPullExtraImages,
+		"Extra OCI images to pull in the image")
+
+	_ = kubeadmCmd.MarkFlagRequired("kubernetes-version")
+}

--- a/cmd/image-builder/command_root.go
+++ b/cmd/image-builder/command_root.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+
+	"github.com/spf13/cobra"
+	cliflag "k8s.io/component-base/cli/flag"
+	logsv1 "k8s.io/component-base/logs/api/v1"
+
+	"github.com/lxc/cluster-api-provider-incus/internal/incus"
+)
+
+var (
+	rootCmd = &cobra.Command{
+		Use:          "image-builder",
+		SilenceUsage: true,
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+			if err := logsv1.ValidateAndApply(logOptions, nil); err != nil {
+				return fmt.Errorf("failed to configure logging: %w", err)
+			}
+
+			switch cfg.instanceType {
+			case "container", "virtual-machine":
+			default:
+				return fmt.Errorf("invalid value for --instance-type argument %q, must be one of [container, virtual-machine]", cfg.instanceType)
+			}
+
+			switch cfg.ubuntuVersion {
+			case "22.04", "24.04":
+			default:
+				return fmt.Errorf("invalid value for --ubuntu-version argument %q, must be one of [22.04, 24.04]", cfg.ubuntuVersion)
+			}
+
+			opts, err := incus.NewOptionsFromConfigFile(cfg.configFile, cfg.configRemoteName, false)
+			if err != nil {
+				return fmt.Errorf("failed to read client credentials: %w", err)
+			}
+
+			client, err = incus.New(gCtx, opts)
+			if err != nil {
+				return fmt.Errorf("failed to create incus client: %w", err)
+			}
+
+			return nil
+		},
+	}
+)
+
+func init() {
+	rootCmd.AddGroup(&cobra.Group{ID: "build", Title: "Available Image Types:"})
+	rootCmd.AddCommand(kubeadmCmd, haproxyCmd)
+
+	logsv1.AddFlags(logOptions, rootCmd.PersistentFlags())
+	rootCmd.SetGlobalNormalizationFunc(cliflag.WordSepNormalizeFunc)
+	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
+
+	rootCmd.PersistentFlags().StringVar(&cfg.configFile, "config-file", "",
+		"Read client configuration from file")
+	rootCmd.PersistentFlags().StringVar(&cfg.configRemoteName, "config-remote-name", "",
+		"Override remote to use from configuration file")
+
+	rootCmd.PersistentFlags().StringVar(&cfg.ubuntuVersion, "ubuntu-version", defaultUbuntuVersion,
+		"Ubuntu version to use to launch instance (one of 22.04|24.04)")
+
+	rootCmd.PersistentFlags().StringVar(&cfg.instanceName, "instance-name", defaultInstanceName,
+		"Name for the builder instance")
+	rootCmd.PersistentFlags().StringVar(&cfg.instanceType, "instance-type", defaultInstanceType,
+		"Type of image to build (one of container|virtual-machine)")
+	rootCmd.PersistentFlags().StringSliceVar(&cfg.instanceProfiles, "instance-profile", defaultInstanceProfiles,
+		"Profiles to use to launch the builder instance")
+
+	rootCmd.PersistentFlags().StringVar(&cfg.imageAlias, "image-alias", "",
+		"Create image with alias. If not specified, a default is used based on config")
+
+	rootCmd.PersistentFlags().StringVar(&cfg.outputFile, "output", "image.tar.gz",
+		"Output file for exported image")
+
+}

--- a/cmd/image-builder/config.go
+++ b/cmd/image-builder/config.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"context"
+
+	"k8s.io/component-base/logs"
+	"k8s.io/klog/v2"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	"github.com/lxc/cluster-api-provider-incus/internal/incus"
+)
+
+var (
+	gCtx       context.Context
+	gLogger    = ctrl.Log
+	logOptions = logs.NewOptions()
+
+	// command-line arguments
+	cfg struct {
+		// client configuration
+		configFile       string
+		configRemoteName string
+
+		// base image configuration
+		ubuntuVersion string
+
+		// builder configuration
+		instanceName     string
+		instanceProfiles []string
+		instanceType     string
+
+		// image alias configuration
+		imageAlias string
+
+		// output
+		outputFile string
+	}
+
+	kubeadmCfg struct {
+		kubernetesVersion string
+		pullExtraImages   []string
+	}
+
+	// runtime configuration
+	client *incus.Client
+)
+
+func init() {
+	gCtx = ctrl.SetupSignalHandler()
+	ctrl.SetLogger(klog.Background())
+	gCtx = ctrl.LoggerInto(gCtx, gLogger)
+}

--- a/cmd/image-builder/default.go
+++ b/cmd/image-builder/default.go
@@ -1,0 +1,14 @@
+package main
+
+var (
+	defaultUbuntuVersion = "24.04"
+
+	defaultInstanceName     = "capn-builder"
+	defaultInstanceType     = "container"
+	defaultInstanceProfiles = []string{"default"}
+
+	defaultPullExtraImages = []string{
+		"docker.io/flannel/flannel-cni-plugin:v1.6.0-flannel1",
+		"docker.io/flannel/flannel:v0.26.3",
+	}
+)

--- a/cmd/image-builder/main.go
+++ b/cmd/image-builder/main.go
@@ -1,0 +1,11 @@
+package main
+
+import (
+	"os"
+)
+
+func main() {
+	if err := rootCmd.Execute(); err != nil {
+		os.Exit(1)
+	}
+}

--- a/cmd/image-builder/run_stage_cleanup_instance.go
+++ b/cmd/image-builder/run_stage_cleanup_instance.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"fmt"
+	"io"
+	"os"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/lxc/cluster-api-provider-incus/internal/static"
+)
+
+type cleanupInstanceStage struct{}
+
+func (*cleanupInstanceStage) name() string { return "cleanup-instance" }
+
+// cat cleanup-instance.sh | incus exec capn-builder -- bash -s
+func (*cleanupInstanceStage) run(ctx context.Context) error {
+	log.FromContext(ctx).V(1).Info("Running cleanup-instance.sh script")
+
+	var stdout, stderr io.Writer
+	if log.FromContext(ctx).V(4).Enabled() {
+		stdout = os.Stdout
+		stderr = os.Stderr
+	}
+
+	stdin := bytes.NewBufferString(static.CleanupInstanceScript())
+	if err := client.RunCommand(ctx, cfg.instanceName, []string{"bash", "-s"}, stdin, stdout, stderr); err != nil {
+		return fmt.Errorf("failed to run cleanup-instance.sh script: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/image-builder/run_stage_cleanup_instance.go
+++ b/cmd/image-builder/run_stage_cleanup_instance.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	_ "embed"
 	"fmt"
 	"io"
 	"os"
@@ -13,12 +12,12 @@ import (
 	"github.com/lxc/cluster-api-provider-incus/internal/static"
 )
 
-type cleanupInstanceStage struct{}
+type stageCleanupInstance struct{}
 
-func (*cleanupInstanceStage) name() string { return "cleanup-instance" }
+func (*stageCleanupInstance) name() string { return "cleanup-instance" }
 
 // cat cleanup-instance.sh | incus exec capn-builder -- bash -s
-func (*cleanupInstanceStage) run(ctx context.Context) error {
+func (*stageCleanupInstance) run(ctx context.Context) error {
 	log.FromContext(ctx).V(1).Info("Running cleanup-instance.sh script")
 
 	var stdout, stderr io.Writer

--- a/cmd/image-builder/run_stage_create_instance.go
+++ b/cmd/image-builder/run_stage_create_instance.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/lxc/incus/v6/shared/api"
+)
+
+type createInstanceStage struct{}
+
+func (*createInstanceStage) name() string { return "create-instance" }
+
+// incus launch image:ubuntu/24.04/cloud
+// incus launch image:ubuntu/24.04/cloud --vm -d root,size=5GiB
+func (*createInstanceStage) run(ctx context.Context) error {
+	// Fetch server information
+	server, _, err := client.Client.GetServer()
+	if err != nil {
+		return fmt.Errorf("failed to get server information: %w", err)
+	}
+
+	// Incus and LXD have diverged image servers for Ubuntu images, making it easy to confuse users.
+	// To address the issue, we allow a special prefix `ubuntu:VERSION` for image names:
+	var image api.InstanceSource
+	switch server.Environment.Server {
+	case "incus":
+		image = api.InstanceSource{
+			Alias:    fmt.Sprintf("ubuntu/%s/cloud", cfg.ubuntuVersion),
+			Server:   "https://images.linuxcontainers.org",
+			Protocol: "simplestreams",
+			Type:     "image",
+		}
+	case "lxd":
+		image = api.InstanceSource{
+			Alias:    cfg.ubuntuVersion,
+			Server:   "https://cloud-images.ubuntu.com/releases/",
+			Protocol: "simplestreams",
+			Type:     "image",
+		}
+	default:
+		return fmt.Errorf("unknown server name %q, must be one of [incus, lxd]", server.Environment.Server)
+	}
+
+	// LXD needs security.nesting=true for containers to be able to pull images
+	var config map[string]string
+	if cfg.instanceType == "container" {
+		config = map[string]string{
+			"security.nesting": "true",
+		}
+	}
+
+	instanceConfig := api.InstancesPost{
+		Name:   cfg.instanceName,
+		Source: image,
+		Type:   api.InstanceType(cfg.instanceType),
+		InstancePut: api.InstancePut{
+			Config:   config,
+			Profiles: cfg.instanceProfiles,
+		},
+	}
+
+	// set size of root volume to 5GB for virtual machines
+	if cfg.instanceType == "virtual-machine" {
+		pools, err := client.Client.GetStoragePools()
+		if err != nil {
+			return fmt.Errorf("failed to list storage pools: %w", err)
+		}
+
+		for _, pool := range pools {
+			if pool.Status == api.StoragePoolStatusCreated {
+				instanceConfig.InstancePut.Devices = map[string]map[string]string{
+					"root": {
+						"type": "disk",
+						"pool": pool.Name,
+						"path": "/",
+						"size": "5GiB",
+					},
+				}
+			}
+		}
+	}
+
+	if err := client.CreateAndWaitForInstance(ctx, instanceConfig); err != nil {
+		return fmt.Errorf("failed to launch builder instance: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/image-builder/run_stage_create_instance.go
+++ b/cmd/image-builder/run_stage_create_instance.go
@@ -7,13 +7,13 @@ import (
 	"github.com/lxc/incus/v6/shared/api"
 )
 
-type createInstanceStage struct{}
+type stageCreateInstance struct{}
 
-func (*createInstanceStage) name() string { return "create-instance" }
+func (*stageCreateInstance) name() string { return "create-instance" }
 
 // incus launch image:ubuntu/24.04/cloud
 // incus launch image:ubuntu/24.04/cloud --vm -d root,size=5GiB
-func (*createInstanceStage) run(ctx context.Context) error {
+func (*stageCreateInstance) run(ctx context.Context) error {
 	// Fetch server information
 	server, _, err := client.Client.GetServer()
 	if err != nil {

--- a/cmd/image-builder/run_stage_export_image.go
+++ b/cmd/image-builder/run_stage_export_image.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	incus "github.com/lxc/incus/v6/client"
+	"github.com/lxc/incus/v6/shared/ioprogress"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type exportImageStage struct{}
+
+func (*exportImageStage) name() string { return "export-image" }
+
+// incus image export capn-builder-image
+func (s *exportImageStage) run(ctx context.Context) (rerr error) {
+	image, _, err := client.Client.GetImageAlias(cfg.imageAlias)
+	if err != nil {
+		return fmt.Errorf("failed to find image for alias %q: %w", cfg.imageAlias, err)
+	}
+
+	output, err := os.Create(cfg.outputFile)
+	if err != nil {
+		return fmt.Errorf("failed to create output file: %w", err)
+	}
+	defer func() {
+		_ = output.Close()
+		if rerr != nil {
+			_ = os.Remove(cfg.outputFile)
+		}
+	}()
+
+	resp, err := client.Client.GetImageFile(image.Target, incus.ImageFileRequest{
+		MetaFile: output,
+		ProgressHandler: func(progress ioprogress.ProgressData) {
+			log.FromContext(ctx).V(2).WithValues("progress", progress.Text).Info("Downloading image")
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to download image: %w", err)
+	}
+
+	log.FromContext(ctx).V(1).WithValues("image", resp).Info("Downloaded image")
+	if err := output.Truncate(resp.MetaSize); err != nil {
+		return fmt.Errorf("failed to truncate output file: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/image-builder/run_stage_export_image.go
+++ b/cmd/image-builder/run_stage_export_image.go
@@ -10,12 +10,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-type exportImageStage struct{}
+type stageExportImage struct{}
 
-func (*exportImageStage) name() string { return "export-image" }
+func (*stageExportImage) name() string { return "export-image" }
 
 // incus image export capn-builder-image
-func (s *exportImageStage) run(ctx context.Context) (rerr error) {
+func (s *stageExportImage) run(ctx context.Context) (rerr error) {
 	image, _, err := client.Client.GetImageAlias(cfg.imageAlias)
 	if err != nil {
 		return fmt.Errorf("failed to find image for alias %q: %w", cfg.imageAlias, err)

--- a/cmd/image-builder/run_stage_generate_manifest.go
+++ b/cmd/image-builder/run_stage_generate_manifest.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	_ "embed"
 	"fmt"
 	"io"
 	"os"
@@ -13,12 +12,12 @@ import (
 	"github.com/lxc/cluster-api-provider-incus/internal/static"
 )
 
-type generateManifestStage struct{}
+type stageGenerateManifest struct{}
 
-func (*generateManifestStage) name() string { return "generate-manifest" }
+func (*stageGenerateManifest) name() string { return "generate-manifest" }
 
 // cat generate-manifest.sh | incus exec capn-builder -- bash -s
-func (*generateManifestStage) run(ctx context.Context) error {
+func (*stageGenerateManifest) run(ctx context.Context) error {
 	log.FromContext(ctx).V(1).Info("Running generate-manifest.sh script")
 
 	var stdout, stderr io.Writer

--- a/cmd/image-builder/run_stage_generate_manifest.go
+++ b/cmd/image-builder/run_stage_generate_manifest.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"fmt"
+	"io"
+	"os"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/lxc/cluster-api-provider-incus/internal/static"
+)
+
+type generateManifestStage struct{}
+
+func (*generateManifestStage) name() string { return "generate-manifest" }
+
+// cat generate-manifest.sh | incus exec capn-builder -- bash -s
+func (*generateManifestStage) run(ctx context.Context) error {
+	log.FromContext(ctx).V(1).Info("Running generate-manifest.sh script")
+
+	var stdout, stderr io.Writer
+	if log.FromContext(ctx).V(4).Enabled() {
+		stdout = os.Stdout
+		stderr = os.Stderr
+	}
+
+	stdin := bytes.NewBufferString(static.GenerateManifestScript())
+	if err := client.RunCommand(ctx, cfg.instanceName, []string{"bash", "-s"}, stdin, stdout, stderr); err != nil {
+		return fmt.Errorf("failed to run generate-manifest.sh script: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/image-builder/run_stage_install_haproxy.go
+++ b/cmd/image-builder/run_stage_install_haproxy.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	_ "embed"
 	"fmt"
 	"io"
 	"os"
@@ -13,13 +12,13 @@ import (
 	"github.com/lxc/cluster-api-provider-incus/internal/static"
 )
 
-type installHaproxyStage struct{}
+type stageInstallHaproxy struct{}
 
-func (*installHaproxyStage) name() string { return "install-haproxy" }
+func (*stageInstallHaproxy) name() string { return "install-haproxy" }
 
 // cat embed/50-install-haproxy.sh | incus exec capn-builder -- bash -s
 // incus config set capn-builder user.capn.stage.install-haproxy=true
-func (*installHaproxyStage) run(ctx context.Context) error {
+func (*stageInstallHaproxy) run(ctx context.Context) error {
 	instance, etag, err := client.Client.GetInstance(cfg.instanceName)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve instance info: %w", err)

--- a/cmd/image-builder/run_stage_install_haproxy.go
+++ b/cmd/image-builder/run_stage_install_haproxy.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	_ "embed"
+	"fmt"
+	"io"
+	"os"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/lxc/cluster-api-provider-incus/internal/static"
+)
+
+type installHaproxyStage struct{}
+
+func (*installHaproxyStage) name() string { return "install-haproxy" }
+
+// cat embed/50-install-haproxy.sh | incus exec capn-builder -- bash -s
+// incus config set capn-builder user.capn.stage.install-haproxy=true
+func (*installHaproxyStage) run(ctx context.Context) error {
+	instance, etag, err := client.Client.GetInstance(cfg.instanceName)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve instance info: %w", err)
+	}
+
+	if instance.Config["user.capn.stage.install-haproxy"] == "true" {
+		log.FromContext(ctx).V(1).Info("Stage already run")
+		return nil
+	}
+
+	stdin := bytes.NewBufferString(static.InstallHaproxyScript())
+
+	var stdout, stderr io.Writer
+	if log.FromContext(ctx).V(4).Enabled() {
+		stdout = os.Stdout
+		stderr = os.Stderr
+	}
+
+	log.FromContext(ctx).V(1).Info("Running install-haproxy.sh script")
+	if err := client.RunCommand(ctx, cfg.instanceName, []string{"bash", "-s"}, stdin, stdout, stderr); err != nil {
+		return fmt.Errorf("failed to run install-haproxy.sh script: %w", err)
+	}
+
+	log.FromContext(ctx).V(1).Info("Set user.capn.stage.install-haproxy=true on instance")
+	instance.InstancePut.Config["user.capn.stage.install-haproxy"] = "true"
+	if _, err := client.Client.UpdateInstance(cfg.instanceName, instance.InstancePut, etag); err != nil {
+		return fmt.Errorf("failed to mark install-haproxy stage on instance: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/image-builder/run_stage_install_kubeadm.go
+++ b/cmd/image-builder/run_stage_install_kubeadm.go
@@ -12,13 +12,13 @@ import (
 	"github.com/lxc/cluster-api-provider-incus/internal/static"
 )
 
-type installKubeadmStage struct{}
+type stageInstallKubeadm struct{}
 
-func (*installKubeadmStage) name() string { return "install-kubeadm" }
+func (*stageInstallKubeadm) name() string { return "install-kubeadm" }
 
 // cat embed/50-install-kubeadm.sh | incus exec capn-builder -- bash -s -- $kubernetesVersion
 // incus config set capn-builder user.capn.stage.install-kubeadm=true
-func (*installKubeadmStage) run(ctx context.Context) error {
+func (*stageInstallKubeadm) run(ctx context.Context) error {
 	instance, etag, err := client.Client.GetInstance(cfg.instanceName)
 	if err != nil {
 		return fmt.Errorf("failed to retrieve instance info: %w", err)

--- a/cmd/image-builder/run_stage_install_kubeadm.go
+++ b/cmd/image-builder/run_stage_install_kubeadm.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/lxc/cluster-api-provider-incus/internal/static"
+)
+
+type installKubeadmStage struct{}
+
+func (*installKubeadmStage) name() string { return "install-kubeadm" }
+
+// cat embed/50-install-kubeadm.sh | incus exec capn-builder -- bash -s -- $kubernetesVersion
+// incus config set capn-builder user.capn.stage.install-kubeadm=true
+func (*installKubeadmStage) run(ctx context.Context) error {
+	instance, etag, err := client.Client.GetInstance(cfg.instanceName)
+	if err != nil {
+		return fmt.Errorf("failed to retrieve instance info: %w", err)
+	}
+
+	if instance.Config["user.capn.stage.install-kubeadm"] == "true" {
+		log.FromContext(ctx).V(1).Info("Stage already run")
+		return nil
+	}
+
+	stdin := bytes.NewBufferString(static.InstallKubeadmScript())
+
+	var stdout, stderr io.Writer
+	if log.FromContext(ctx).V(4).Enabled() {
+		stdout = os.Stdout
+		stderr = os.Stderr
+	}
+
+	log.FromContext(ctx).V(1).Info("Running install-kubeadm.sh script")
+	if err := client.RunCommand(ctx, cfg.instanceName, []string{"bash", "-s", "--", kubeadmCfg.kubernetesVersion}, stdin, stdout, stderr); err != nil {
+		return fmt.Errorf("failed to run install-kubeadm.sh script: %w", err)
+	}
+
+	log.FromContext(ctx).V(1).Info("Set user.capn.stage.install-kubeadm=true on instance")
+	instance.InstancePut.Config["user.capn.stage.install-kubeadm"] = "true"
+	if _, err := client.Client.UpdateInstance(cfg.instanceName, instance.InstancePut, etag); err != nil {
+		return fmt.Errorf("failed to mark install-kubeadm stage on instance: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/image-builder/run_stage_post_run_commands.go
+++ b/cmd/image-builder/run_stage_post_run_commands.go
@@ -1,0 +1,11 @@
+package main
+
+import "context"
+
+type postRunCommandsStage struct{}
+
+func (*postRunCommandsStage) name() string { return "post-run-commands" }
+
+func (*postRunCommandsStage) run(ctx context.Context) error {
+	return nil
+}

--- a/cmd/image-builder/run_stage_post_run_commands.go
+++ b/cmd/image-builder/run_stage_post_run_commands.go
@@ -2,10 +2,10 @@ package main
 
 import "context"
 
-type postRunCommandsStage struct{}
+type stagePostRunCommands struct{}
 
-func (*postRunCommandsStage) name() string { return "post-run-commands" }
+func (*stagePostRunCommands) name() string { return "post-run-commands" }
 
-func (*postRunCommandsStage) run(ctx context.Context) error {
+func (*stagePostRunCommands) run(ctx context.Context) error {
 	return nil
 }

--- a/cmd/image-builder/run_stage_pre_run_commands.go
+++ b/cmd/image-builder/run_stage_pre_run_commands.go
@@ -1,0 +1,11 @@
+package main
+
+import "context"
+
+type preRunCommandsStage struct{}
+
+func (*preRunCommandsStage) name() string { return "pre-run-commands" }
+
+func (*preRunCommandsStage) run(ctx context.Context) error {
+	return nil
+}

--- a/cmd/image-builder/run_stage_pre_run_commands.go
+++ b/cmd/image-builder/run_stage_pre_run_commands.go
@@ -2,10 +2,10 @@ package main
 
 import "context"
 
-type preRunCommandsStage struct{}
+type stagePreRunCommands struct{}
 
-func (*preRunCommandsStage) name() string { return "pre-run-commands" }
+func (*stagePreRunCommands) name() string { return "pre-run-commands" }
 
-func (*preRunCommandsStage) run(ctx context.Context) error {
+func (*stagePreRunCommands) run(ctx context.Context) error {
 	return nil
 }

--- a/cmd/image-builder/run_stage_publish_haproxy_image.go
+++ b/cmd/image-builder/run_stage_publish_haproxy_image.go
@@ -7,12 +7,12 @@ import (
 	"time"
 )
 
-type publishHaproxyImageStage struct{}
+type stagePublishHaproxyImage struct{}
 
-func (*publishHaproxyImageStage) name() string { return "publish-image" }
+func (*stagePublishHaproxyImage) name() string { return "publish-image" }
 
 // incus publish capn-builder capn-builder-image
-func (s *publishHaproxyImageStage) run(ctx context.Context) error {
+func (s *stagePublishHaproxyImage) run(ctx context.Context) error {
 	now := time.Now()
 	serial := fmt.Sprintf("%d%02d%02d%02d%02d", now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute())
 

--- a/cmd/image-builder/run_stage_publish_haproxy_image.go
+++ b/cmd/image-builder/run_stage_publish_haproxy_image.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"time"
+)
+
+type publishHaproxyImageStage struct{}
+
+func (*publishHaproxyImageStage) name() string { return "publish-image" }
+
+// incus publish capn-builder capn-builder-image
+func (s *publishHaproxyImageStage) run(ctx context.Context) error {
+	now := time.Now()
+	serial := fmt.Sprintf("%d%02d%02d%02d%02d", now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute())
+
+	if err := client.PublishImage(ctx, cfg.instanceName, cfg.imageAlias, map[string]string{
+		"architecture": runtime.GOARCH,
+		"name":         fmt.Sprintf("haproxy %s %s", getUbuntuReleaseName(cfg.ubuntuVersion), runtime.GOARCH),
+		"description":  fmt.Sprintf("haproxy %s %s (%s)", getUbuntuReleaseName(cfg.ubuntuVersion), runtime.GOARCH, serial),
+		"os":           "haproxy",
+		"release":      getUbuntuReleaseName(cfg.ubuntuVersion),
+		"variant":      "ubuntu",
+		"serial":       serial,
+	}); err != nil {
+		return fmt.Errorf("failed to create image from instance: %w", err)
+	}
+	return nil
+}

--- a/cmd/image-builder/run_stage_publish_kubeadm_image.go
+++ b/cmd/image-builder/run_stage_publish_kubeadm_image.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"time"
+)
+
+type publishKubeadmImageStage struct{}
+
+func (*publishKubeadmImageStage) name() string { return "publish-image" }
+
+// incus publish capn-builder capn-builder-image
+func (*publishKubeadmImageStage) run(ctx context.Context) error {
+	now := time.Now()
+	serial := fmt.Sprintf("%d%02d%02d%02d%02d", now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute())
+
+	if err := client.PublishImage(ctx, cfg.instanceName, cfg.imageAlias, map[string]string{
+		"architecture": runtime.GOARCH,
+		"name":         fmt.Sprintf("kubeadm %s ubuntu %s %s", kubeadmCfg.kubernetesVersion, getUbuntuReleaseName(cfg.ubuntuVersion), runtime.GOARCH),
+		"description":  fmt.Sprintf("kubeadm %s ubuntu %s %s (%s)", kubeadmCfg.kubernetesVersion, getUbuntuReleaseName(cfg.ubuntuVersion), runtime.GOARCH, serial),
+		"os":           "kubeadm",
+		"release":      kubeadmCfg.kubernetesVersion,
+		"variant":      "ubuntu",
+		"serial":       serial,
+	}); err != nil {
+		return fmt.Errorf("failed to create image from instance: %w", err)
+	}
+	return nil
+}

--- a/cmd/image-builder/run_stage_publish_kubeadm_image.go
+++ b/cmd/image-builder/run_stage_publish_kubeadm_image.go
@@ -7,12 +7,12 @@ import (
 	"time"
 )
 
-type publishKubeadmImageStage struct{}
+type stagePublishKubeadmImage struct{}
 
-func (*publishKubeadmImageStage) name() string { return "publish-image" }
+func (*stagePublishKubeadmImage) name() string { return "publish-image" }
 
 // incus publish capn-builder capn-builder-image
-func (*publishKubeadmImageStage) run(ctx context.Context) error {
+func (*stagePublishKubeadmImage) run(ctx context.Context) error {
 	now := time.Now()
 	serial := fmt.Sprintf("%d%02d%02d%02d%02d", now.Year(), now.Month(), now.Day(), now.Hour(), now.Minute())
 

--- a/cmd/image-builder/run_stage_pull_extra_images.go
+++ b/cmd/image-builder/run_stage_pull_extra_images.go
@@ -8,12 +8,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
-type pullExtraImagesStage struct{}
+type stagePullExtraImages struct{}
 
-func (*pullExtraImagesStage) name() string { return "pull-extra-images" }
+func (*stagePullExtraImages) name() string { return "pull-extra-images" }
 
 // incus exec capn-builder -- crictl pull $image
-func (*pullExtraImagesStage) run(ctx context.Context) error {
+func (*stagePullExtraImages) run(ctx context.Context) error {
 	for _, image := range kubeadmCfg.pullExtraImages {
 		log.FromContext(ctx).V(1).WithValues("image", image).Info("Pulling image")
 		if err := client.RunCommand(ctx, cfg.instanceName, []string{"crictl", "pull", image}, nil, os.Stdout, os.Stderr); err != nil {

--- a/cmd/image-builder/run_stage_pull_images.go
+++ b/cmd/image-builder/run_stage_pull_images.go
@@ -1,0 +1,25 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"os"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type pullExtraImagesStage struct{}
+
+func (*pullExtraImagesStage) name() string { return "pull-extra-images" }
+
+// incus exec capn-builder -- crictl pull $image
+func (*pullExtraImagesStage) run(ctx context.Context) error {
+	for _, image := range kubeadmCfg.pullExtraImages {
+		log.FromContext(ctx).V(1).WithValues("image", image).Info("Pulling image")
+		if err := client.RunCommand(ctx, cfg.instanceName, []string{"crictl", "pull", image}, nil, os.Stdout, os.Stderr); err != nil {
+			return fmt.Errorf("failed to pull image %q: %w", image, err)
+		}
+	}
+
+	return nil
+}

--- a/cmd/image-builder/run_stage_remove_instance.go
+++ b/cmd/image-builder/run_stage_remove_instance.go
@@ -1,0 +1,18 @@
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+type removeInstanceStage struct{}
+
+func (*removeInstanceStage) name() string { return "remove-instance" }
+
+// incus rm capn-builder --force
+func (*removeInstanceStage) run(ctx context.Context) error {
+	if err := client.ForceRemoveInstance(ctx, cfg.instanceName); err != nil {
+		return fmt.Errorf("failed to delete instance: %w", err)
+	}
+	return nil
+}

--- a/cmd/image-builder/run_stage_remove_instance.go
+++ b/cmd/image-builder/run_stage_remove_instance.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 )
 
-type removeInstanceStage struct{}
+type stageRemoveInstance struct{}
 
-func (*removeInstanceStage) name() string { return "remove-instance" }
+func (*stageRemoveInstance) name() string { return "remove-instance" }
 
 // incus rm capn-builder --force
-func (*removeInstanceStage) run(ctx context.Context) error {
+func (*stageRemoveInstance) run(ctx context.Context) error {
 	if err := client.ForceRemoveInstance(ctx, cfg.instanceName); err != nil {
 		return fmt.Errorf("failed to delete instance: %w", err)
 	}

--- a/cmd/image-builder/run_stage_stop_instance.go
+++ b/cmd/image-builder/run_stage_stop_instance.go
@@ -5,12 +5,12 @@ import (
 	"fmt"
 )
 
-type stopInstanceStage struct{}
+type stageStopInstance struct{}
 
-func (*stopInstanceStage) name() string { return "stop-instance" }
+func (*stageStopInstance) name() string { return "stop-instance" }
 
 // incus stop capn-builder
-func (*stopInstanceStage) run(ctx context.Context) error {
+func (*stageStopInstance) run(ctx context.Context) error {
 	if err := client.StopInstance(ctx, cfg.instanceName); err != nil {
 		return fmt.Errorf("failed to stop instance: %w", err)
 	}

--- a/cmd/image-builder/run_stage_stop_instance.go
+++ b/cmd/image-builder/run_stage_stop_instance.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"context"
+	"fmt"
+)
+
+type stopInstanceStage struct{}
+
+func (*stopInstanceStage) name() string { return "stop-instance" }
+
+// incus stop capn-builder
+func (*stopInstanceStage) run(ctx context.Context) error {
+	if err := client.StopInstance(ctx, cfg.instanceName); err != nil {
+		return fmt.Errorf("failed to stop instance: %w", err)
+	}
+
+	return nil
+}

--- a/cmd/image-builder/run_stages.go
+++ b/cmd/image-builder/run_stages.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"context"
+	"fmt"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type stage interface {
+	name() string
+	run(ctx context.Context) error
+}
+
+func runStages(stages ...stage) error {
+	for idx, stage := range stages {
+		ctx := log.IntoContext(gCtx, log.FromContext(gCtx).WithValues("stage.name", stage.name(), "stage.index", fmt.Sprintf("%d/%d", idx+1, len(stages))))
+
+		log.FromContext(ctx).Info("Starting stage")
+		if err := stage.run(ctx); err != nil {
+			return fmt.Errorf("failure during stage %q: %w", stage.name(), err)
+		}
+		log.FromContext(ctx).Info("Completed stage")
+	}
+
+	return nil
+}

--- a/cmd/image-builder/util.go
+++ b/cmd/image-builder/util.go
@@ -1,0 +1,14 @@
+package main
+
+func getUbuntuReleaseName(version string) string {
+	switch version {
+	case "20.04":
+		return "focal"
+	case "22.04":
+		return "jammy"
+	case "24.04":
+		return "noble"
+	default:
+		return version
+	}
+}

--- a/docs/book/src/howto/images/index.md
+++ b/docs/book/src/howto/images/index.md
@@ -7,4 +7,4 @@ Images on the default server do not support all Kubernetes versions, and availab
 - [`kubeadm`](./kubeadm.md): used to launch the Kubernetes control plane and worker node machines
 - [`haproxy`](./haproxy.md): used to launch the load balancer container in development clusters
 
-> **NOTE**: The images on the default simplesteams server are meant for evaluation and development purposes only. Administrators should build and maintain their own images for production clusters.
+> **NOTE**: The images on the default simplestreams server are meant for evaluation and development purposes only. Administrators should build and maintain their own images for production clusters.

--- a/docs/book/src/static/v0.1/image-cleanup.sh
+++ b/docs/book/src/static/v0.1/image-cleanup.sh
@@ -1,1 +1,0 @@
-../../../../../hack/scripts/images/stages/99-cleanup.sh

--- a/docs/book/src/static/v0.1/install-haproxy.sh
+++ b/docs/book/src/static/v0.1/install-haproxy.sh
@@ -1,1 +1,0 @@
-../../../../../hack/scripts/images/stages/50-install-haproxy.sh

--- a/go.mod
+++ b/go.mod
@@ -3,9 +3,11 @@ module github.com/lxc/cluster-api-provider-incus
 go 1.23.8
 
 require (
+	github.com/blang/semver/v4 v4.0.0
 	github.com/lxc/incus/v6 v6.8.0
 	github.com/onsi/ginkgo/v2 v2.22.1
 	github.com/onsi/gomega v1.36.2
+	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	k8s.io/api v0.32.0
 	k8s.io/apimachinery v0.32.0
@@ -33,7 +35,6 @@ require (
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
-	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/cloudflare/circl v1.3.7 // indirect
@@ -106,7 +107,6 @@ require (
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.7.0 // indirect
-	github.com/spf13/cobra v1.8.1 // indirect
 	github.com/spf13/viper v1.19.0 // indirect
 	github.com/stoewer/go-strcase v1.2.0 // indirect
 	github.com/subosito/gotenv v1.6.0 // indirect

--- a/hack/scripts/ci/setup-lxd.sh
+++ b/hack/scripts/ci/setup-lxd.sh
@@ -5,7 +5,13 @@ DIR="$(dirname "$(realpath "$0")")"
 if ! snap list lxd; then
   sudo apt update
   sudo apt install snapd -y
-  sudo snap install lxd --channel 5.21/stable
+  sudo snap wait core seed.loaded
+
+  timeout 5m sh -c '
+    while ! sudo snap install lxd --channel 5.21/stable; do
+      echo retry failed install
+    done
+  '
 fi
 
 sudo snap refresh lxd --channel 5.21/stable

--- a/internal/incus/lxc_hack_builder_instances.go
+++ b/internal/incus/lxc_hack_builder_instances.go
@@ -1,0 +1,88 @@
+package incus
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	incus "github.com/lxc/incus/v6/client"
+	"github.com/lxc/incus/v6/shared/api"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+func (c *Client) CreateAndWaitForInstance(ctx context.Context, instance api.InstancesPost) error {
+	if err := c.createInstanceIfNotExists(ctx, instance); err != nil {
+		return fmt.Errorf("failed to ensure instance exists: %w", err)
+	}
+	if err := c.ensureInstanceRunning(ctx, instance.Name); err != nil {
+		return fmt.Errorf("failed to ensure instance is running: %w", err)
+	}
+	if _, err := c.waitForInstanceAddress(ctx, instance.Name); err != nil {
+		return fmt.Errorf("failed to wait for instance address: %w", err)
+	}
+	return nil
+}
+
+func (c *Client) StopInstance(ctx context.Context, name string) error {
+	state, _, err := c.Client.GetInstanceState(name)
+	if err != nil {
+		if strings.Contains(err.Error(), "Instance not found") {
+			log.FromContext(ctx).V(2).Info("Instance does not exist")
+			return nil
+		}
+		return fmt.Errorf("failed to GetInstanceState: %w", err)
+	}
+
+	// stop instance if running
+	if state.Pid != 0 {
+		log.FromContext(ctx).WithValues("status", state.Status, "pid", state.Pid).V(2).Info("Stopping instance")
+		if err := c.wait(ctx, "UpdateInstanceState", func() (incus.Operation, error) {
+			return c.Client.UpdateInstanceState(name, api.InstanceStatePut{Action: "stop", Force: true}, "")
+		}); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) CreateInstanceSnapshot(ctx context.Context, instanceName string, snapshotName string) error {
+	if _, _, err := c.Client.GetInstanceSnapshot(instanceName, snapshotName); err == nil {
+		log.FromContext(ctx).V(2).Info("Instance snapshot already exists")
+		return nil
+	}
+	return c.wait(ctx, "CreateInstanceSnapshot", func() (incus.Operation, error) {
+		return c.Client.CreateInstanceSnapshot(instanceName, api.InstanceSnapshotsPost{
+			Name: snapshotName,
+		})
+	})
+}
+
+func (c *Client) PublishImage(ctx context.Context, instanceName string, imageAliasName string, imageProperties map[string]string) error {
+	if _, _, err := c.Client.GetImageAlias(imageAliasName); err == nil {
+		log.FromContext(ctx).V(2).Info("Image alias already exists")
+		return nil
+	}
+
+	return c.wait(ctx, "CreateImage", func() (incus.Operation, error) {
+		return c.Client.CreateImage(api.ImagesPost{
+			ImagePut: api.ImagePut{
+				Properties: imageProperties,
+				Public:     true,
+				ExpiresAt:  time.Now().AddDate(10, 0, 0),
+			},
+			Source: &api.ImagesPostSource{
+				Type: "instance",
+				Name: instanceName,
+			},
+			Aliases: []api.ImageAlias{
+				{Name: imageAliasName},
+			},
+		}, nil)
+	})
+}
+
+func (c *Client) ForceRemoveInstance(ctx context.Context, instanceName string) error {
+	return c.forceRemoveInstanceIfExists(ctx, instanceName)
+}

--- a/internal/incus/lxc_load_balancer_lxc.go
+++ b/internal/incus/lxc_load_balancer_lxc.go
@@ -159,7 +159,7 @@ func (l *loadBalancerLXC) Inspect(ctx context.Context) map[string]string {
 		{name: "haproxy.cfg", command: []string{"cat", "/etc/haproxy/haproxy.cfg"}},
 	} {
 		var stdout, stderr bytes.Buffer
-		if err := l.lxcClient.RunCommand(ctx, l.name, item.command, &stdout, &stderr); err != nil {
+		if err := l.lxcClient.RunCommand(ctx, l.name, item.command, nil, &stdout, &stderr); err != nil {
 			result[fmt.Sprintf("%s.error", item.name)] = fmt.Errorf("failed to RunCommand %v on %s: %w", item.command, l.name, err).Error()
 		}
 		result[item.name] = fmt.Sprintf("%s\n%s\n", stdout.String(), stderr.String())

--- a/internal/incus/lxc_run_command.go
+++ b/internal/incus/lxc_run_command.go
@@ -10,13 +10,14 @@ import (
 )
 
 // RunCommand on a specified instance, and allow retrieving the stdout and stderr. It returns an error if execution failed.
-func (c *Client) RunCommand(ctx context.Context, instanceName string, command []string, stdout io.Writer, stderr io.Writer) error {
+func (c *Client) RunCommand(ctx context.Context, instanceName string, command []string, stdin io.Reader, stdout io.Writer, stderr io.Writer) error {
 	var status int
 	if err := c.wait(ctx, "ExecInstance", func() (incus.Operation, error) {
 		op, err := c.Client.ExecInstance(instanceName, api.InstanceExecPost{
 			Command:   command,
 			WaitForWS: true,
 		}, &incus.InstanceExecArgs{
+			Stdin:  stdin,
 			Stdout: stdout,
 			Stderr: stderr,
 		})

--- a/internal/static/embed/install-haproxy.sh
+++ b/internal/static/embed/install-haproxy.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -xeu
+
+# Usage:
+#  $ /opt/cluster-api/install-haproxy.sh
+
+set -xeu
+
+apt update
+apt install haproxy -y --no-install-recommends

--- a/internal/static/scripts.go
+++ b/internal/static/scripts.go
@@ -6,6 +6,9 @@ var (
 	//go:embed embed/install-kubeadm.sh
 	installKubeadmScript string
 
+	//go:embed embed/install-haproxy.sh
+	installHaproxyScript string
+
 	//go:embed embed/generate-manifest.sh
 	generateManifestScript string
 
@@ -15,6 +18,10 @@ var (
 
 func InstallKubeadmScript() string {
 	return installKubeadmScript
+}
+
+func InstallHaproxyScript() string {
+	return installHaproxyScript
 }
 
 func GenerateManifestScript() string {

--- a/templates/clusterclass-capn-default.yaml
+++ b/templates/clusterclass-capn-default.yaml
@@ -68,6 +68,9 @@ spec:
               flavor:
                 description: Instance size, e.g. "c1-m1" for 1 CPU and 1 GB RAM
                 type: string
+              image:
+                type: string
+                description: Override the image to use for provisioning the load balancer instance.
               profiles:
                 description: List of profiles to apply on the instance
                 type: array
@@ -199,12 +202,16 @@ spec:
             {{ if hasKey .loadBalancer "lxc" }}
             loadBalancer:
               lxc:
-                instanceSpec: {{ if and (not .loadBalancer.lxc.flavor) (not .loadBalancer.lxc.profiles) }}{}{{ end }}
+                instanceSpec: {{ if and (not .loadBalancer.lxc.image) (not .loadBalancer.lxc.flavor) (not .loadBalancer.lxc.profiles) }}{}{{ end }}
             {{ if .loadBalancer.lxc.flavor }}
                   flavor: {{ .loadBalancer.lxc.flavor }}
             {{ end }}
             {{ if .loadBalancer.lxc.profiles }}
                   profiles: {{ .loadBalancer.lxc.profiles | toJson }}
+            {{ end }}
+            {{ if .loadBalancer.lxc.image }}
+                  image:
+                    name: {{ .loadBalancer.lxc.image | quote }}
             {{ end }}
             {{ end }}
             {{ if hasKey .loadBalancer "oci" }}

--- a/test/e2e/shared/log_collector.go
+++ b/test/e2e/shared/log_collector.go
@@ -104,7 +104,7 @@ func (o IncusLogCollector) CollectMachineLog(ctx context.Context, managementClus
 		defer cancel()
 
 		var stdout, stderr bytes.Buffer
-		if err := client.RunCommand(commandCtx, instanceName, item.command, &stdout, &stderr); err != nil {
+		if err := client.RunCommand(commandCtx, instanceName, item.command, nil, &stdout, &stderr); err != nil {
 			errs = append(errs, fmt.Errorf("failed to run command %v: %w", item.command, err))
 		}
 		if v := stdout.Bytes(); len(v) > 0 {


### PR DESCRIPTION
### Summary

- Add `./cmd/image-builder` utility that can be used to build haproxy and kubeadm images.
- Add documentation describing how to build and use kubeadm images (replaces previous manual steps and running scripts)
- Add GitHub action to build images for target Kubernetes versions

