### PR TITLE
Cleanup files when building instance images

### DIFF
--- a/internal/static/embed/cleanup-instance.sh
+++ b/internal/static/embed/cleanup-instance.sh
@@ -8,8 +8,7 @@ set -xeu
 apt-get purge -y \
   ubuntu-pro-client libx11-data iso-codes language-pack-en-base \
   vim openssh-client groff-base gnupg polkitd \
-  python-apt-common python3-apt python3-babel python3-pygments \
-  python3-launchpadlib python3-markdown-it python3-mdurl
+  python3-babel python3-pygments python3-launchpadlib python3-markdown-it python3-mdurl
 
 apt-get autoremove -y && apt-get clean && apt-get autoclean
 rm -rf \

--- a/internal/static/embed/cleanup-instance.sh
+++ b/internal/static/embed/cleanup-instance.sh
@@ -5,26 +5,40 @@
 
 set -xeu
 
-apt-get autoremove && apt-get clean && apt-get autoclean
+apt-get purge -y \
+  ubuntu-pro-client libx11-data iso-codes language-pack-en-base \
+  vim openssh-client groff-base gnupg polkitd \
+  python-apt-common python3-apt python3-babel python3-pygments \
+  python3-launchpadlib python3-markdown-it python3-mdurl
+
+apt-get autoremove -y && apt-get clean && apt-get autoclean
 rm -rf \
-  /var/lib/apt/lists \
-  /var/cache/apt \
+  /home/ubuntu/.bash_history \
   /home/ubuntu/.cache \
   /home/ubuntu/.config \
   /home/ubuntu/.gnupg \
   /home/ubuntu/.ssh \
   /home/ubuntu/.sudo_as_admin_successful \
-  /home/ubuntu/.bash_history \
+  /root/.bash_history \
   /root/.cache \
   /root/.config \
   /root/.gnupg \
   /root/.ssh \
   /root/.sudo_as_admin_successful \
-  /root/.bash_history \
-  /var/lib/swcatalog \
+  /tmp \
   /usr/share/doc \
-  /usr/share/man
+  /usr/share/man \
+  /var/cache/apt \
+  /var/cache/swcatalog \
+  /var/lib/apt/lists \
+  /var/lib/swcatalog \
+  /var/log \
+  /var/tmp
+
+mkdir -p /var/tmp /var/log /tmp
 
 if which cloud-init; then
   cloud-init clean --machine-id --seed --logs
 fi
+
+find /usr/lib/python3* | grep __pycache__ | xargs rm -rf


### PR DESCRIPTION
### Summary

- remove documentation, caches, language packs
- remove unused utils
- remove unused python packages
- remove pycache files
- remove temporary files from builder instance

### Notes

Observed reduced image size:

- haproxy image (123MB -> 89MB)
- kubeadm image v1.32.3 (727MB -> 668MB)
- kubeadm virtual machine image v1.32.3 (1030MB -> 1010MB) 