### PR TITLE
Build images with kube-flannel version v0.26.7

### DIFF
--- a/cmd/exp/image-builder/default.go
+++ b/cmd/exp/image-builder/default.go
@@ -8,7 +8,7 @@ var (
 	defaultInstanceProfiles = []string{"default"}
 
 	defaultPullExtraImages = []string{
-		"docker.io/flannel/flannel-cni-plugin:v1.6.0-flannel1",
-		"docker.io/flannel/flannel:v0.26.3",
+		"ghcr.io/flannel-io/flannel-cni-plugin:v1.6.2-flannel1",
+		"ghcr.io/flannel-io/flannel:v0.26.7",
 	}
 )


### PR DESCRIPTION
### Summary

Update kube-flannel version loaded in kubeadm images (v0.26.3 -> v0.26.7)

### Notes

We will update kube-flannel version used in cluster templates after this PR is merged (to have images with new kube-flannel version)