### PR TITLE
Only run `QuickStart KVM` e2e test on amd64

### DIFF
--- a/test/e2e/suites/e2e/quick_start_kvm_test.go
+++ b/test/e2e/suites/e2e/quick_start_kvm_test.go
@@ -1,4 +1,4 @@
-//go:build e2e
+//go:build e2e && amd64
 
 package e2e
 


### PR DESCRIPTION
### Summary

Only run `QuickStart KVM` test on amd64, since we do not currently have any kvm arm64 instances to build images or test with.