### PR TITLE
Revert "Build images with kube-flannel version v0.26.7 (#72)"

### DIFF
--- a/cmd/exp/image-builder/default.go
+++ b/cmd/exp/image-builder/default.go
@@ -8,7 +8,7 @@ var (
 	defaultInstanceProfiles = []string{"default"}
 
 	defaultPullExtraImages = []string{
-		"ghcr.io/flannel-io/flannel-cni-plugin:v1.6.2-flannel1",
-		"ghcr.io/flannel-io/flannel:v0.26.7",
+		"docker.io/flannel/flannel-cni-plugin:v1.6.0-flannel1",
+		"docker.io/flannel/flannel:v0.26.3",
 	}
 )


### PR DESCRIPTION
This reverts commit d01884b8440349c437ba565570789b6cbf371d24.

### Summary

`kube-flannel` v0.26.7 seems to be failing with new kubeadm images, whereas v0.26.3 works just fine. Revert the change made in #72 while we troubleshoot why this happens.