### PR TITLE
Address image builder issues in GitHub Actions

### DIFF
--- a/cmd/exp/image-builder/cmd_kubeadm.go
+++ b/cmd/exp/image-builder/cmd_kubeadm.go
@@ -47,6 +47,7 @@ var (
 				&stagePublishKubeadmImage{},
 				&stageExportImage{},
 				&stageRemoveInstance{},
+				&stageValidateKubeadmImage{},
 			)
 		},
 	}

--- a/cmd/exp/image-builder/cmd_kubeadm.go
+++ b/cmd/exp/image-builder/cmd_kubeadm.go
@@ -25,7 +25,7 @@ var (
 			}
 
 			if cfg.imageAlias == "" {
-				cfg.imageAlias = fmt.Sprintf("kubeadm-%s-u%s-%s", kubeadmCfg.kubernetesVersion, cfg.ubuntuVersion, cfg.instanceType)
+				cfg.imageAlias = fmt.Sprintf("kubeadm-%s-%s", kubeadmCfg.kubernetesVersion, cfg.instanceType)
 			}
 
 			log.FromContext(gCtx).WithValues(

--- a/cmd/exp/image-builder/cmd_root.go
+++ b/cmd/exp/image-builder/cmd_root.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"time"
 
 	"github.com/spf13/cobra"
 	cliflag "k8s.io/component-base/cli/flag"
@@ -28,8 +29,9 @@ var (
 		// image alias configuration
 		imageAlias string
 
-		// skip stages
-		skipStages []string
+		// build step configuration
+		skipStages          []string
+		instanceGracePeriod time.Duration
 
 		// output
 		outputFile string
@@ -102,6 +104,9 @@ func init() {
 	rootCmd.PersistentFlags().StringSliceVar(&cfg.skipStages, "skip", nil,
 		"Skip stages while building the image")
 	_ = rootCmd.PersistentFlags().MarkHidden("skip")
+
+	rootCmd.PersistentFlags().DurationVar(&cfg.instanceGracePeriod, "instance-grace-period", defaultInstanceGracePeriod,
+		"[advanced] Grace period before stopping instance, such that all disk writes complete")
 
 	rootCmd.PersistentFlags().StringVar(&cfg.outputFile, "output", "image.tar.gz",
 		"Output file for exported image")

--- a/cmd/exp/image-builder/default.go
+++ b/cmd/exp/image-builder/default.go
@@ -1,11 +1,15 @@
 package main
 
+import "time"
+
 var (
 	defaultUbuntuVersion = "24.04"
 
 	defaultInstanceName     = "capn-builder"
 	defaultInstanceType     = "container"
 	defaultInstanceProfiles = []string{"default"}
+
+	defaultInstanceGracePeriod = 2 * time.Minute
 
 	defaultPullExtraImages = []string{
 		"docker.io/flannel/flannel-cni-plugin:v1.6.0-flannel1",

--- a/cmd/exp/image-builder/run_stage_stop_instance.go
+++ b/cmd/exp/image-builder/run_stage_stop_instance.go
@@ -3,6 +3,9 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
+
+	"sigs.k8s.io/controller-runtime/pkg/log"
 )
 
 type stageStopInstance struct{}
@@ -11,6 +14,12 @@ func (*stageStopInstance) name() string { return "stop-instance" }
 
 // incus stop capn-builder
 func (*stageStopInstance) run(ctx context.Context) error {
+	log.FromContext(ctx).WithValues("period", cfg.instanceGracePeriod).Info("Waiting for grace period before stopping instance")
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(cfg.instanceGracePeriod):
+	}
 	if err := client.StopInstance(ctx, cfg.instanceName); err != nil {
 		return fmt.Errorf("failed to stop instance: %w", err)
 	}

--- a/cmd/exp/image-builder/run_stage_validate_image.go
+++ b/cmd/exp/image-builder/run_stage_validate_image.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/lxc/cluster-api-provider-incus/internal/static"
+	"github.com/lxc/incus/v6/shared/api"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type stageValidateKubeadmImage struct{}
+
+func (*stageValidateKubeadmImage) name() string { return "validate-kubeadm-image" }
+
+// incus launch capn-builder-image t1
+// cat validate-kubeadm-image.sh | incus exec t1 -- bash -s
+// incus rm t1 --force
+func (*stageValidateKubeadmImage) run(ctx context.Context) error {
+	instanceName := fmt.Sprintf("%s-validate", cfg.imageAlias)
+	if err := client.CreateAndWaitForInstance(ctx, api.InstancesPost{
+		Name: instanceName,
+		Type: api.InstanceType(cfg.instanceType),
+		Source: api.InstanceSource{
+			Type:  "image",
+			Alias: cfg.imageAlias,
+		},
+		InstancePut: api.InstancePut{
+			Profiles: cfg.instanceProfiles,
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to launch validation instance: %w", err)
+	}
+
+	stdin := bytes.NewBufferString(static.ValidateKubeadmImageScript())
+
+	var stdout, stderr io.Writer
+	if log.FromContext(ctx).V(4).Enabled() {
+		stdout = os.Stdout
+		stderr = os.Stderr
+	}
+
+	log.FromContext(ctx).V(1).Info("Running validate-kubeadm-image.sh script")
+	if err := client.RunCommand(ctx, instanceName, []string{"bash", "-s"}, stdin, stdout, stderr); err != nil {
+		return fmt.Errorf("failed to run validate-kubeadm-image.sh script: %w", err)
+	}
+
+	if err := client.ForceRemoveInstance(ctx, instanceName); err != nil {
+		return fmt.Errorf("failed to delete instance: %w", err)
+	}
+	return nil
+}

--- a/cmd/exp/image-builder/run_stage_validate_image.go
+++ b/cmd/exp/image-builder/run_stage_validate_image.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/lxc/cluster-api-provider-incus/internal/static"
 	"github.com/lxc/incus/v6/shared/api"
@@ -21,6 +22,9 @@ func (*stageValidateKubeadmImage) name() string { return "validate-kubeadm-image
 // incus rm t1 --force
 func (*stageValidateKubeadmImage) run(ctx context.Context) error {
 	instanceName := fmt.Sprintf("%s-validate", cfg.instanceName)
+
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("instance.name", instanceName))
+
 	if err := client.CreateAndWaitForInstance(ctx, api.InstancesPost{
 		Name: instanceName,
 		Type: api.InstanceType(cfg.instanceType),
@@ -33,6 +37,23 @@ func (*stageValidateKubeadmImage) run(ctx context.Context) error {
 		},
 	}); err != nil {
 		return fmt.Errorf("failed to launch validation instance: %w", err)
+	}
+
+	log.FromContext(ctx).V(1).Info("Waiting for instance agent to come up")
+	waitInstanceCh := make(chan error, 1)
+	go func() {
+		<-time.After(5 * time.Minute)
+		waitInstanceCh <- fmt.Errorf("timed out after 5 minutes")
+	}()
+	go func() {
+		for client.RunCommand(ctx, instanceName, []string{"echo", "hi"}, nil, nil, nil) != nil {
+			<-time.After(time.Second)
+		}
+		waitInstanceCh <- nil
+	}()
+
+	if err := <-waitInstanceCh; err != nil {
+		return fmt.Errorf("failed to wait for instance agent to come up: %w", err)
 	}
 
 	stdin := bytes.NewBufferString(static.ValidateKubeadmImageScript())

--- a/cmd/exp/image-builder/run_stage_validate_image.go
+++ b/cmd/exp/image-builder/run_stage_validate_image.go
@@ -20,7 +20,7 @@ func (*stageValidateKubeadmImage) name() string { return "validate-kubeadm-image
 // cat validate-kubeadm-image.sh | incus exec t1 -- bash -s
 // incus rm t1 --force
 func (*stageValidateKubeadmImage) run(ctx context.Context) error {
-	instanceName := fmt.Sprintf("%s-validate", cfg.imageAlias)
+	instanceName := fmt.Sprintf("%s-validate", cfg.instanceName)
 	if err := client.CreateAndWaitForInstance(ctx, api.InstancesPost{
 		Name: instanceName,
 		Type: api.InstanceType(cfg.instanceType),

--- a/cmd/exp/image-builder/run_stage_validate_image.go
+++ b/cmd/exp/image-builder/run_stage_validate_image.go
@@ -8,9 +8,10 @@ import (
 	"os"
 	"time"
 
-	"github.com/lxc/cluster-api-provider-incus/internal/static"
 	"github.com/lxc/incus/v6/shared/api"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	"github.com/lxc/cluster-api-provider-incus/internal/static"
 )
 
 type stageValidateKubeadmImage struct{}

--- a/internal/static/embed/validate-kubeadm-image.sh
+++ b/internal/static/embed/validate-kubeadm-image.sh
@@ -9,7 +9,6 @@ set -xeu
 containerd --version
 runc --version
 crictl --version
-crictl images
 
 # kubernetes
 kubelet --version

--- a/internal/static/embed/validate-kubeadm-image.sh
+++ b/internal/static/embed/validate-kubeadm-image.sh
@@ -12,7 +12,7 @@ crictl --version
 crictl images
 
 # kubernetes
-kubelet --version1
+kubelet --version
 kubeadm version -o yaml
 kubectl version -o yaml --client
 

--- a/internal/static/embed/validate-kubeadm-image.sh
+++ b/internal/static/embed/validate-kubeadm-image.sh
@@ -1,0 +1,20 @@
+#!/bin/sh -xeu
+
+# Usage:
+#  $ /opt/cluster-api-lxc/validate-kubeadm-image.sh
+
+set -xeu
+
+# container runtime
+containerd --version
+runc --version
+crictl --version
+crictl images
+
+# kubernetes
+kubelet --version1
+kubeadm version -o yaml
+kubectl version -o yaml --client
+
+# flanneld binary (if exists)
+find /var/lib/containerd | grep flanneld | xargs -t --replace={} bash -c "{} --version"

--- a/internal/static/scripts.go
+++ b/internal/static/scripts.go
@@ -14,10 +14,17 @@ var (
 
 	//go:embed embed/cleanup-instance.sh
 	cleanupInstanceScript string
+
+	//go:embed embed/validate-kubeadm-image.sh
+	validateKubeadmImageScript string
 )
 
 func InstallKubeadmScript() string {
 	return installKubeadmScript
+}
+
+func ValidateKubeadmImageScript() string {
+	return validateKubeadmImageScript
 }
 
 func InstallHaproxyScript() string {


### PR DESCRIPTION
### Summary

Fix issues with corrupted kvm images built in GitHub actions

### Changes

- Add a grace period before stopping instances, such that disk writes complete without issues
- Add a validation step in built images, to ensure that binaries are not corrupted