### PR TITLE
Use Kubernetes v1.33.0 for testing, test linux/arm64 in CI

### DIFF
--- a/.github/workflows/test-e2e-conformance.yml
+++ b/.github/workflows/test-e2e-conformance.yml
@@ -9,11 +9,13 @@ on:
 
 jobs:
   test-e2e:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         infrastructure: [lxd, incus]
+        arch: [amd64, arm64]
+
+    runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-e2e-conformance.yml
+++ b/.github/workflows/test-e2e-conformance.yml
@@ -40,5 +40,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: artifacts-${{ matrix.infrastructure }}
+          name: artifacts-${{ matrix.infrastructure }}-${{ matrix.arch }}
           path: _artifacts

--- a/.github/workflows/test-e2e-full.yml
+++ b/.github/workflows/test-e2e-full.yml
@@ -8,11 +8,13 @@ on:
 
 jobs:
   test-e2e:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         infrastructure: [lxd, incus]
+        arch: [amd64, arm64]
+
+    runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-e2e-full.yml
+++ b/.github/workflows/test-e2e-full.yml
@@ -39,5 +39,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: artifacts-${{ matrix.infrastructure }}
+          name: artifacts-${{ matrix.infrastructure }}-${{ matrix.arch }}
           path: _artifacts

--- a/.github/workflows/test-e2e-pr.yml
+++ b/.github/workflows/test-e2e-pr.yml
@@ -5,11 +5,13 @@ on:
 
 jobs:
   test-e2e:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         infrastructure: [lxd, incus]
+        arch: [amd64, arm64]
+
+    runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/test-e2e-pr.yml
+++ b/.github/workflows/test-e2e-pr.yml
@@ -36,5 +36,5 @@ jobs:
         uses: actions/upload-artifact@v4
         if: always()
         with:
-          name: artifacts-${{ matrix.infrastructure }}
+          name: artifacts-${{ matrix.infrastructure }}-${{ matrix.arch }}
           path: _artifacts

--- a/docs/book/src/howto/developer-guide.md
+++ b/docs/book/src/howto/developer-guide.md
@@ -125,7 +125,7 @@ On a separate window, generate a cluster manifest and deploy:
 ```bash
 export LOAD_BALANCER="lxc: {}"
 export LXC_SECRET_NAME="lxc-secret"
-export KUBERNETES_VERSION="v1.32.3"
+export KUBERNETES_VERSION="v1.33.0"
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 

--- a/test/e2e/data/config.yaml
+++ b/test/e2e/data/config.yaml
@@ -82,9 +82,9 @@ providers:
 # allowing the same e2e config file to be re-used in different prow jobs e.g. each one with a K8s version permutation
 variables:
   KUBE_CONTEXT: kind-capn-e2e
-  KUBERNETES_VERSION: v1.32.3
-  KUBERNETES_VERSION_UPGRADE_FROM: v1.31.5
-  KUBERNETES_VERSION_UPGRADE_TO: v1.32.3
+  KUBERNETES_VERSION: v1.33.0
+  KUBERNETES_VERSION_UPGRADE_FROM: v1.32.4
+  KUBERNETES_VERSION_UPGRADE_TO: v1.33.0
 
   CNI: ../../data/cni/kube-flannel.yaml
 

--- a/test/e2e/suites/e2e/quick_start_kvm_test.go
+++ b/test/e2e/suites/e2e/quick_start_kvm_test.go
@@ -1,23 +1,42 @@
-//go:build e2e && amd64
+//go:build e2e
 
 package e2e
 
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 
 	"sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/util"
 
+	"github.com/lxc/cluster-api-provider-incus/internal/incus"
 	"github.com/lxc/cluster-api-provider-incus/internal/ptr"
 	"github.com/lxc/cluster-api-provider-incus/test/e2e/shared"
 
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 )
 
 var _ = Describe("QuickStart", func() {
 	Context("KVM", Label("PRBlocking"), Label("Flaky"), func() {
 		BeforeEach(func(ctx context.Context) {
+			client, err := incus.New(ctx, e2eCtx.Settings.LXCClientOptions)
+			Expect(err).ToNot(HaveOccurred())
+			info, _, err := client.Client.GetServer()
+			Expect(err).ToNot(HaveOccurred())
+
+			// skip if server cannot launch kvm instances
+			if !slices.Contains(strings.Split(info.Environment.Driver, " | "), "qemu") {
+				Skip(fmt.Sprintf("Server is missing driver qemu, supported drivers are: %q", info.Environment.Driver))
+			}
+
+			// skip if server is not amd64 (kvm images are only available for amd64)
+			if !slices.Contains(info.Environment.Architectures, "x86_64") {
+				Skip(fmt.Sprintf("QuickStart KVM test requires amd64, but server only supports the following architectures: %v", info.Environment.Architectures))
+			}
+
 			e2eCtx.OverrideVariables(map[string]string{
 				"WORKER_MACHINE_TYPE": "virtual-machine",
 			})


### PR DESCRIPTION
### Summary

Use `kubeadm/v1.33.0` and `kubeadm/v1.32.4`, which now support `arm64` architectures as well.

Test with arm64 in CI. 