### PR TITLE
prepare for v0.6.0 release

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -16,3 +16,6 @@ releaseSeries:
 - major: 0
   minor: 5
   contract: v1beta1
+- major: 0
+  minor: 6
+  contract: v1beta1


### PR DESCRIPTION
### Summary

add `v0.6` release metadata