### PR TITLE
Hide kubernetes flags from image-builder and simplestreams binaries

### DIFF
--- a/cmd/exp/image-builder/cmd_root.go
+++ b/cmd/exp/image-builder/cmd_root.go
@@ -83,6 +83,12 @@ func init() {
 	rootCmd.SetGlobalNormalizationFunc(cliflag.WordSepNormalizeFunc)
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 
+	_ = rootCmd.PersistentFlags().MarkHidden("kubeconfig")
+	_ = rootCmd.PersistentFlags().MarkHidden("log-text-info-buffer-size")
+	_ = rootCmd.PersistentFlags().MarkHidden("log-flush-frequency")
+	_ = rootCmd.PersistentFlags().MarkHidden("log-text-split-stream")
+	_ = rootCmd.PersistentFlags().MarkHidden("logging-format")
+
 	rootCmd.PersistentFlags().StringVar(&cfg.configFile, "config-file", "",
 		"Read client configuration from file")
 	rootCmd.PersistentFlags().StringVar(&cfg.configRemoteName, "config-remote-name", "",

--- a/cmd/exp/simplestreams/cmd_root.go
+++ b/cmd/exp/simplestreams/cmd_root.go
@@ -42,6 +42,12 @@ func init() {
 	rootCmd.SetGlobalNormalizationFunc(cliflag.WordSepNormalizeFunc)
 	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 
+	_ = rootCmd.PersistentFlags().MarkHidden("kubeconfig")
+	_ = rootCmd.PersistentFlags().MarkHidden("log-text-info-buffer-size")
+	_ = rootCmd.PersistentFlags().MarkHidden("log-flush-frequency")
+	_ = rootCmd.PersistentFlags().MarkHidden("log-text-split-stream")
+	_ = rootCmd.PersistentFlags().MarkHidden("logging-format")
+
 	rootCmd.AddGroup(&cobra.Group{ID: "operations", Title: "Available operations:"})
 	rootCmd.AddCommand(importCmd, showCmd)
 


### PR DESCRIPTION
### Summary

These flags are added by Kubernetes internal machinery, and are unrelated to the tools.