### PR TITLE
Add `LXCMachine.spec.target` field to enable configurable machine placement

### DIFF
--- a/api/v1alpha2/lxccluster_types.go
+++ b/api/v1alpha2/lxccluster_types.go
@@ -163,6 +163,22 @@ type LXCLoadBalancerMachineSpec struct {
 	//
 	// +optional
 	Image LXCMachineImageSource `json:"image"`
+
+	// Target where the load balancer machine should be provisioned, when
+	// infrastructure is a production cluster.
+	//
+	// Can be one of:
+	//
+	//   - `name`: where `name` is the name of a cluster member.
+	//   - `@name`: where `name` is the name of a cluster group.
+	//
+	// Target is ignored when infrastructure is single-node (e.g. for
+	// development purposes).
+	//
+	// For more information on cluster groups, you can refer to https://linuxcontainers.org/incus/docs/main/explanation/clustering/#cluster-groups
+	//
+	// +optional
+	Target string `json:"target,omitempty"`
 }
 
 // LXCClusterStatus defines the observed state of LXCCluster.

--- a/api/v1alpha2/lxcmachine_types.go
+++ b/api/v1alpha2/lxcmachine_types.go
@@ -102,6 +102,22 @@ type LXCMachineSpec struct {
 	//
 	// +optional
 	Image LXCMachineImageSource `json:"image"`
+
+	// Target where the machine should be provisioned, when infrastructure
+	// is a production cluster.
+	//
+	// Can be one of:
+	//
+	//   - `name`: where `name` is the name of a cluster member.
+	//   - `@name`: where `name` is the name of a cluster group.
+	//
+	// Target is ignored when infrastructure is single-node (e.g. for
+	// development purposes).
+	//
+	// For more information on cluster groups, you can refer to https://linuxcontainers.org/incus/docs/main/explanation/clustering/#cluster-groups
+	//
+	// +optional
+	Target string `json:"target"`
 }
 
 type LXCMachineImageSource struct {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclusters.yaml
@@ -145,6 +145,21 @@ spec:
                             items:
                               type: string
                             type: array
+                          target:
+                            description: |-
+                              Target where the load balancer machine should be provisioned, when
+                              infrastructure is a production cluster.
+
+                              Can be one of:
+
+                                - `name`: where `name` is the name of a cluster member.
+                                - `@name`: where `name` is the name of a cluster group.
+
+                              Target is ignored when infrastructure is single-node (e.g. for
+                              development purposes).
+
+                              For more information on cluster groups, you can refer to https://linuxcontainers.org/incus/docs/main/explanation/clustering/#cluster-groups
+                            type: string
                         type: object
                     type: object
                   oci:
@@ -208,6 +223,21 @@ spec:
                             items:
                               type: string
                             type: array
+                          target:
+                            description: |-
+                              Target where the load balancer machine should be provisioned, when
+                              infrastructure is a production cluster.
+
+                              Can be one of:
+
+                                - `name`: where `name` is the name of a cluster member.
+                                - `@name`: where `name` is the name of a cluster group.
+
+                              Target is ignored when infrastructure is single-node (e.g. for
+                              development purposes).
+
+                              For more information on cluster groups, you can refer to https://linuxcontainers.org/incus/docs/main/explanation/clustering/#cluster-groups
+                            type: string
                         type: object
                     type: object
                   ovn:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclustertemplates.yaml
@@ -166,6 +166,21 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                  target:
+                                    description: |-
+                                      Target where the load balancer machine should be provisioned, when
+                                      infrastructure is a production cluster.
+
+                                      Can be one of:
+
+                                        - `name`: where `name` is the name of a cluster member.
+                                        - `@name`: where `name` is the name of a cluster group.
+
+                                      Target is ignored when infrastructure is single-node (e.g. for
+                                      development purposes).
+
+                                      For more information on cluster groups, you can refer to https://linuxcontainers.org/incus/docs/main/explanation/clustering/#cluster-groups
+                                    type: string
                                 type: object
                             type: object
                           oci:
@@ -230,6 +245,21 @@ spec:
                                     items:
                                       type: string
                                     type: array
+                                  target:
+                                    description: |-
+                                      Target where the load balancer machine should be provisioned, when
+                                      infrastructure is a production cluster.
+
+                                      Can be one of:
+
+                                        - `name`: where `name` is the name of a cluster member.
+                                        - `@name`: where `name` is the name of a cluster group.
+
+                                      Target is ignored when infrastructure is single-node (e.g. for
+                                      development purposes).
+
+                                      For more information on cluster groups, you can refer to https://linuxcontainers.org/incus/docs/main/explanation/clustering/#cluster-groups
+                                    type: string
                                 type: object
                             type: object
                           ovn:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcmachines.yaml
@@ -153,6 +153,21 @@ spec:
                 description: ProviderID is the container name in ProviderID format
                   (lxc:///<containername>).
                 type: string
+              target:
+                description: |-
+                  Target where the machine should be provisioned, when infrastructure
+                  is a production cluster.
+
+                  Can be one of:
+
+                    - `name`: where `name` is the name of a cluster member.
+                    - `@name`: where `name` is the name of a cluster group.
+
+                  Target is ignored when infrastructure is single-node (e.g. for
+                  development purposes).
+
+                  For more information on cluster groups, you can refer to https://linuxcontainers.org/incus/docs/main/explanation/clustering/#cluster-groups
+                type: string
             type: object
           status:
             description: LXCMachineStatus defines the observed state of LXCMachine.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcmachinetemplates.yaml
@@ -169,6 +169,21 @@ spec:
                         description: ProviderID is the container name in ProviderID
                           format (lxc:///<containername>).
                         type: string
+                      target:
+                        description: |-
+                          Target where the machine should be provisioned, when infrastructure
+                          is a production cluster.
+
+                          Can be one of:
+
+                            - `name`: where `name` is the name of a cluster member.
+                            - `@name`: where `name` is the name of a cluster group.
+
+                          Target is ignored when infrastructure is single-node (e.g. for
+                          development purposes).
+
+                          For more information on cluster groups, you can refer to https://linuxcontainers.org/incus/docs/main/explanation/clustering/#cluster-groups
+                        type: string
                     type: object
                 required:
                 - spec

--- a/docs/book/src/SUMMARY.md
+++ b/docs/book/src/SUMMARY.md
@@ -6,6 +6,10 @@
 
 ---
 
+- [Machine Placement](./howto/machine-placement.md)
+
+---
+
 - [Build base images](./howto/images/index.md)
   - [Kubeadm](./howto/images/kubeadm.md)
   - [Haproxy](./howto/images/haproxy.md)

--- a/docs/book/src/howto/machine-placement.md
+++ b/docs/book/src/howto/machine-placement.md
@@ -1,0 +1,125 @@
+# Machine Placement
+
+CAPN works both for single node infrastructure (aimed at local development), as well as production clusters.
+
+In a production cluster, it is usually desirable to ensure that cluster machines are scheduled on a specific hypervisor. For example, control plane machines may run on overprovisioned CPU hypervisors, whereas worker nodes can run on machines with GPUs.
+
+In this page, we explain how to configure cluster groups in an existing cluster, and use them to launch CAPN machines on specific hypervisors.
+
+## Table Of Contents
+
+<!-- toc -->
+
+## Cluster Members and Cluster Groups
+
+Incus uses the concepts of [cluster members](https://linuxcontainers.org/incus/docs/main/explanation/clustering/#cluster-members) (individual hypervisors that are part of the cluster) and [cluster groups](https://linuxcontainers.org/incus/docs/main/explanation/clustering/#cluster-groups) (hypervisors grouped by the user based on specific criteria).
+
+When launching an instance, the target may be set to:
+
+- `<member>`, where `<member>` is the name of a cluster member.
+- `@<group>`, where `<group>` is the name of a cluster group.
+
+## Example cluster
+
+Let's assume a cluster with 6 nodes. 3 CPU nodes `cpu-01`, `cpu-02`, `cpu-03` and 3 GPU nodes `gpu-01`, `gpu-02`, `gpu-03`.
+
+We can see the list of hypervisors that are in the with:
+
+```bash
+incus cluster list
+```
+
+Example output:
+
+```bash
++--------+-----------------------+--------------+--------+-------------------+
+|  NAME  |          URL          | ARCHITECTURE | STATUS |      MESSAGE      |
++--------+-----------------------+--------------+--------+-------------------+
+| cpu-01 | https://10.0.1.1:8443 | x86_64       | ONLINE | Fully operational |
++--------+-----------------------+--------------+--------+-------------------+
+| cpu-02 | https://10.0.1.2:8443 | x86_64       | ONLINE | Fully operational |
++--------+-----------------------+--------------+--------+-------------------+
+| cpu-03 | https://10.0.1.3:8443 | x86_64       | ONLINE | Fully operational |
++--------+-----------------------+--------------+--------+-------------------+
+| gpu-01 | https://10.0.2.1:8443 | x86_64       | ONLINE | Fully operational |
++--------+-----------------------+--------------+--------+-------------------+
+| gpu-02 | https://10.0.2.2:8443 | x86_64       | ONLINE | Fully operational |
++--------+-----------------------+--------------+--------+-------------------+
+| gpu-03 | https://10.0.2.3:8443 | x86_64       | ONLINE | Fully operational |
++--------+-----------------------+--------------+--------+-------------------+
+```
+
+By default, all cluster members are part of the `default` cluster group:
+
+```bash
+incus cluster group show default
+```
+
+Command output can be seen below:
+
+```yaml
+description: Default cluster group
+members:
+- cpu-01
+- cpu-02
+- cpu-03
+- gpu-01
+- gpu-02
+- gpu-03
+config: {}
+name: default
+```
+
+## Configure cluster groups
+
+We want to deploy clusters with control plane machines running on the `cpu-xx` hypervisors, and worker machines running on the `gpu-xx` hypervisors.
+
+In order to do this, we can define two cluster groups, called `cpu-nodes` and `gpu-nodes` respectively:
+
+```bash
+incus cluster group create cpu-nodes
+incus cluster group create gpu-nodes
+```
+
+Then, we assign each node on the respective group:
+
+```bash
+incus cluster group assign cpu-01 cpu-nodes,default
+incus cluster group assign cpu-02 cpu-nodes,default
+incus cluster group assign cpu-03 cpu-nodes,default
+
+incus cluster group assign gpu-01 gpu-nodes,default
+incus cluster group assign gpu-02 gpu-nodes,default
+incus cluster group assign gpu-03 gpu-nodes,default
+```
+
+You can check that the cluster group members have been configured properly:
+
+```bash
+incus cluster group show gpu-nodes
+```
+
+Example output:
+
+```yaml
+description: ""
+members:
+- gpu-01
+- gpu-02
+- gpu-03
+config: {}
+name: gpu
+```
+
+We have now configured our `cpu-nodes` and `gpu-nodes` cluster groups.
+
+## Launch a cluster
+
+Generate a cluster using the [default cluster template](../reference/templates/default.md) and set the following additional configuration:
+
+```bash
+export CONTROL_PLANE_MACHINE_TARGET="@cpu-nodes"
+export WORKER_MACHINE_TARGET="@gpu-nodes"
+```
+
+This will ensure control plane machines are scheduled on a cluster member that is part of the `cpu-nodes` group we configured earlier. Similarly, worker machines will be scheduled on an available member of the `gpu-nodes` group.

--- a/docs/book/src/reference/templates/default.md
+++ b/docs/book/src/reference/templates/default.md
@@ -125,6 +125,10 @@ export WORKER_MACHINE_DEVICES="['eth0,type=nic,network=my-network', 'root,type=d
 
 Instance size for the control plane and worker instances. This is typically specified as `cX-mY`, in which case the instance size will be `X cores` and `Y GB RAM`.
 
+### `CONTROL_PLANE_MACHINE_TARGET` and `WORKER_MACHINE_TARGET`
+
+When infrastructure is a cluster, specify target cluster member or cluster group for control plane and worker machines. See [Machine Placement](../../howto/machine-placement.md) for more details.
+
 ## Cluster Template
 
 ```yaml

--- a/internal/controller/lxcmachine/controller_normal.go
+++ b/internal/controller/lxcmachine/controller_normal.go
@@ -204,7 +204,7 @@ func launchInstance(ctx context.Context, cluster *clusterv1.Cluster, lxcCluster 
 		maps.Copy(instance.Config, profile.Config)
 	}
 
-	return lxcClient.WaitForLaunchInstance(ctx, instance, defaultTemplateFiles)
+	return lxcClient.WithTarget(lxcMachine.Spec.Target).WaitForLaunchInstance(ctx, instance, defaultTemplateFiles)
 }
 
 // defaultTemplateFiles that are injected to LXCMachine instances.

--- a/internal/loadbalancer/manager_lxc.go
+++ b/internal/loadbalancer/manager_lxc.go
@@ -53,7 +53,7 @@ func (l *managerLXC) Create(ctx context.Context) ([]string, error) {
 	}
 
 	log.FromContext(ctx).V(1).Info("Launching load balancer instance")
-	addrs, err := l.lxcClient.WaitForLaunchInstance(ctx, api.InstancesPost{
+	addrs, err := l.lxcClient.WithTarget(l.spec.Target).WaitForLaunchInstance(ctx, api.InstancesPost{
 		Name:         l.name,
 		Type:         api.InstanceTypeContainer,
 		Source:       image,

--- a/internal/loadbalancer/manager_oci.go
+++ b/internal/loadbalancer/manager_oci.go
@@ -59,7 +59,7 @@ func (l *managerOCI) Create(ctx context.Context) ([]string, error) {
 	}
 
 	log.FromContext(ctx).V(1).Info("Launching load balancer instance")
-	addrs, err := l.lxcClient.WaitForLaunchInstance(ctx, api.InstancesPost{
+	addrs, err := l.lxcClient.WithTarget(l.spec.Target).WaitForLaunchInstance(ctx, api.InstancesPost{
 		Name:         l.name,
 		Type:         api.InstanceTypeContainer,
 		Source:       image,

--- a/internal/loadbalancer/manager_oci.go
+++ b/internal/loadbalancer/manager_oci.go
@@ -40,7 +40,7 @@ type managerOCI struct {
 func (l *managerOCI) Create(ctx context.Context) ([]string, error) {
 	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("loadbalancer.instance", l.name))
 
-	if err := l.lxcClient.SupportsInstanceOCI(ctx); err != nil {
+	if err := l.lxcClient.SupportsInstanceOCI(); err != nil {
 		return nil, fmt.Errorf("server does not support OCI containers: %w", err)
 	}
 

--- a/internal/loadbalancer/manager_ovn.go
+++ b/internal/loadbalancer/manager_ovn.go
@@ -33,7 +33,7 @@ func (l *managerOVN) Create(ctx context.Context) ([]string, error) {
 		return nil, utils.TerminalError(fmt.Errorf("network load balancer cannot be provisioned as .spec.loadBalancer.ovn.networkName is not specified"))
 	}
 
-	if err := l.lxcClient.SupportsNetworkLoadBalancers(ctx); err != nil {
+	if err := l.lxcClient.SupportsNetworkLoadBalancers(); err != nil {
 		return nil, fmt.Errorf("server does not support network load balancers: %w", err)
 	}
 

--- a/internal/lxc/client.go
+++ b/internal/lxc/client.go
@@ -13,6 +13,8 @@ import (
 type Client struct {
 	incus.InstanceServer
 
+	serverInfo *api.Server
+
 	progressHandler func(api.Operation)
 }
 
@@ -57,9 +59,14 @@ func New(ctx context.Context, config Configuration, options ...Option) (*Client,
 		client = client.UseProject(config.Project)
 	}
 
+	server, _, err := client.GetServer()
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve server information: %w", err)
+	}
+
 	log.V(2).Info("Initialized client")
 
-	c := &Client{InstanceServer: client}
+	c := &Client{InstanceServer: client, serverInfo: server}
 	for _, o := range options {
 		o(c)
 	}

--- a/internal/lxc/client.go
+++ b/internal/lxc/client.go
@@ -73,3 +73,16 @@ func New(ctx context.Context, config Configuration, options ...Option) (*Client,
 
 	return c, nil
 }
+
+// WithTarget returns a copy of the client and a set target host.
+// WithTarget will ignore the target argument if server is not clustered.
+func (c *Client) WithTarget(target string) *Client {
+	if c.SupportsInstanceTarget() != nil {
+		return c
+	}
+	return &Client{
+		InstanceServer:  c.InstanceServer.UseTarget(target),
+		serverInfo:      c.serverInfo,
+		progressHandler: c.progressHandler,
+	}
+}

--- a/internal/lxc/client_discovery.go
+++ b/internal/lxc/client_discovery.go
@@ -48,3 +48,10 @@ func (c *Client) SupportsInstanceKVM() error {
 func (c *Client) SupportsArchitectures() []string {
 	return slices.Clone(c.serverInfo.Environment.Architectures)
 }
+
+func (c *Client) SupportsInstanceTarget() error {
+	if !c.serverInfo.Environment.ServerClustered {
+		return fmt.Errorf("server is not part of a cluster")
+	}
+	return nil
+}

--- a/internal/lxc/client_discovery.go
+++ b/internal/lxc/client_discovery.go
@@ -3,24 +3,19 @@ package lxc
 import (
 	"context"
 	"fmt"
+	"slices"
+	"strings"
 
 	"k8s.io/apimachinery/pkg/util/sets"
-	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/lxc/cluster-api-provider-incus/internal/utils"
 )
 
 // GetServerName returns one of "incus", "lxd" or "unknown", depending on the server type.
 func (c *Client) GetServerName(ctx context.Context) string {
-	server, _, err := c.GetServer()
-	if err != nil {
-		log.FromContext(ctx).V(4).Error(err, "Failed to GetServer")
-		return "unknown"
-	}
-
-	switch server.Environment.Server {
+	switch c.serverInfo.Environment.Server {
 	case "incus", "lxd":
-		return server.Environment.Server
+		return c.serverInfo.Environment.Server
 	default:
 		return "unknown"
 	}
@@ -29,18 +24,27 @@ func (c *Client) GetServerName(ctx context.Context) string {
 // The built-in Client.HasExtension() from Incus cannot be trusted, as it returns true if we skip the GetServer call.
 // Return the list of extensions that are NOT supported by the server, if any.
 func (c *Client) serverSupportsExtensions(extensions ...string) error {
-	if server, _, err := c.GetServer(); err != nil {
-		return fmt.Errorf("failed to retrieve server information: %w", err)
-	} else if missing := sets.New(extensions...).Difference(sets.New(server.APIExtensions...)).UnsortedList(); len(missing) > 0 {
+	if missing := sets.New(extensions...).Difference(sets.New(c.serverInfo.APIExtensions...)).UnsortedList(); len(missing) > 0 {
 		return utils.TerminalError(fmt.Errorf("required extensions %v are not supported", missing))
 	}
 	return nil
 }
 
-func (c *Client) SupportsInstanceOCI(ctx context.Context) error {
+func (c *Client) SupportsInstanceOCI() error {
 	return c.serverSupportsExtensions("instance_oci")
 }
 
-func (c *Client) SupportsNetworkLoadBalancers(ctx context.Context) error {
+func (c *Client) SupportsNetworkLoadBalancers() error {
 	return c.serverSupportsExtensions("network_load_balancer", "network_load_balancer_health_check")
+}
+
+func (c *Client) SupportsInstanceKVM() error {
+	if !slices.Contains(strings.Split(c.serverInfo.Environment.Driver, " | "), "qemu") {
+		return utils.TerminalError(fmt.Errorf("server is missing driver qemu, supported drivers are: %q", c.serverInfo.Environment.Driver))
+	}
+	return nil
+}
+
+func (c *Client) SupportsArchitectures() []string {
+	return slices.Clone(c.serverInfo.Environment.Architectures)
 }

--- a/templates/cluster-template.rc
+++ b/templates/cluster-template.rc
@@ -34,9 +34,11 @@ export CONTROL_PLANE_MACHINE_TYPE=container     # 'container' or 'virtual-machin
 export CONTROL_PLANE_MACHINE_FLAVOR=c2-m4       # instance type for control plane nodes
 export CONTROL_PLANE_MACHINE_PROFILES=[default] # profiles for control plane nodes
 export CONTROL_PLANE_MACHINE_DEVICES=[]         # override devices for control plane nodes
+export CONTROL_PLANE_MACHINE_TARGET=""          # override target for control plane nodes (e.g. "@default")
 
 # Worker machine configuration
 export WORKER_MACHINE_TYPE=container            # 'container' or 'virtual-machine'
 export WORKER_MACHINE_FLAVOR=c2-m4              # instance type for worker nodes
 export WORKER_MACHINE_PROFILES=[default]        # profiles for worker nodes
 export WORKER_MACHINE_DEVICES=[]                # override devices for worker nodes
+export WORKER_MACHINE_TARGET=""                 # override target for worker nodes (e.g. "@default")

--- a/templates/clusterclass-capn-default.yaml
+++ b/templates/clusterclass-capn-default.yaml
@@ -71,6 +71,10 @@ spec:
               image:
                 type: string
                 description: Override the image to use for provisioning the load balancer instance.
+              target:
+                type: string
+                description: Specify a target for the load balancer instance (name of cluster member, or group)
+                default: ""
               profiles:
                 description: List of profiles to apply on the instance
                 type: array
@@ -83,6 +87,10 @@ spec:
               flavor:
                 type: string
                 description: Instance size, e.g. "c1-m1" for 1 CPU and 1 GB RAM
+              target:
+                type: string
+                description: Specify a target for the load balancer instance (name of cluster member, or group)
+                default: ""
               profiles:
                 type: array
                 description: List of profiles to apply on the instance
@@ -150,6 +158,10 @@ spec:
             items:
               type: string
             description: Override device (e.g. network, storage) configuration for the instance
+          target:
+            type: string
+            description: Specify a target for the instance (name of cluster member, or group)
+            default: ""
           installKubeadm:
             type: boolean
             default: false
@@ -207,6 +219,9 @@ spec:
                   image:
                     name: {{ .loadBalancer.lxc.image | quote }}
             {{ end }}
+            {{ if .loadBalancer.lxc.target }}
+                  target: {{ .loadBalancer.lxc.target }}
+            {{ end }}
             {{ end }}
             {{ if hasKey .loadBalancer "oci" }}
             loadBalancer:
@@ -217,6 +232,9 @@ spec:
             {{ end }}
             {{ if .loadBalancer.oci.profiles }}
                   profiles: {{ .loadBalancer.oci.profiles | toJson }}
+            {{ end }}
+            {{ if .loadBalancer.oci.target }}
+                  target: {{ .loadBalancer.oci.target }}
             {{ end }}
             {{ end }}
             {{ if hasKey .loadBalancer "ovn" }}
@@ -342,6 +360,7 @@ spec:
             devices: {{ .instance.devices | toJson }}
             instanceType: {{ .instance.type | quote }}
             flavor: {{ .instance.flavor | quote }}
+            target: {{ .instance.target | quote }}
             image:
               name: {{ .instance.image | quote }}
   - name: workerInstanceSpec
@@ -363,6 +382,7 @@ spec:
             devices: {{ .instance.devices | toJson }}
             instanceType: {{ .instance.type | quote }}
             flavor: {{ .instance.flavor | quote }}
+            target: {{ .instance.target | quote }}
             image:
               name: {{ .instance.image | quote }}
   - name: controlPlaneInstallKubeadm

--- a/test/e2e/suites/e2e/quick_start_oci_test.go
+++ b/test/e2e/suites/e2e/quick_start_oci_test.go
@@ -24,7 +24,7 @@ var _ = Describe("QuickStart", func() {
 			lxcClient, err := lxc.New(ctx, e2eCtx.Settings.LXCClientOptions)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = lxcClient.SupportsInstanceOCI(ctx)
+			err = lxcClient.SupportsInstanceOCI()
 			Expect(err).To(Or(Succeed(), MatchError(utils.IsTerminalError, "IsTerminalError")))
 			if err != nil {
 				Skip(fmt.Sprintf("Server does not support OCI instances: %v", err))

--- a/test/e2e/suites/e2e/quick_start_ovn_test.go
+++ b/test/e2e/suites/e2e/quick_start_ovn_test.go
@@ -24,7 +24,7 @@ var _ = Describe("QuickStart", func() {
 			lxcClient, err := lxc.New(ctx, e2eCtx.Settings.LXCClientOptions)
 			Expect(err).ToNot(HaveOccurred())
 
-			err = lxcClient.SupportsNetworkLoadBalancers(ctx)
+			err = lxcClient.SupportsNetworkLoadBalancers()
 			Expect(err).To(Or(Succeed(), MatchError(utils.IsTerminalError, "IsTerminalError")))
 			if err != nil {
 				Skip(fmt.Sprintf("Server does not support network load balancer: %v", err))


### PR DESCRIPTION
### Summary

Add LXCMachine `.spec.target` field, which is passed as target for machine launch operations.

This allows cluster administrators to specify placement criteria for cluster machines (e.g. control plane machines run on CPU-heavy hypervisors, worker machines run on GPU enabled hypervisors)