### PR TITLE
Upgrade Go 1.23.8 -> 1.24.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lxc/cluster-api-provider-incus
 
-go 1.23.8
+go 1.24.4
 
 require (
 	github.com/blang/semver/v4 v4.0.0

--- a/hack/tools/go.mod
+++ b/hack/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/lxc/cluster-api-provider-incus/hack/tools
 
-go 1.23.8
+go 1.24.4
 
 require (
 	github.com/ahmetb/gen-crd-api-reference-docs v0.3.0


### PR DESCRIPTION
### Summary

Build binaries and images using Go 1.24.4