### PR TITLE
mirror haproxy and local-path-provisioner images under ghcr.io/lxc/cluster-api-provider-incus

### DIFF
--- a/api/v1alpha2/lxccluster_types.go
+++ b/api/v1alpha2/lxccluster_types.go
@@ -158,7 +158,7 @@ type LXCLoadBalancerMachineSpec struct {
 	// Image to use for provisioning the load balancer machine. If not set,
 	// a default image based on the load balancer type will be used.
 	//
-	//   - "oci": ghcr.io/neoaggelos/cluster-api-provider-lxc/haproxy:v0.0.1
+	//   - "oci": ghcr.io/lxc/cluster-api-provider-incus/haproxy:v20230606-42a2262b
 	//   - "lxc": haproxy from the default simplestreams server
 	//
 	// +optional

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclusters.yaml
@@ -114,7 +114,7 @@ spec:
                               Image to use for provisioning the load balancer machine. If not set,
                               a default image based on the load balancer type will be used.
 
-                                - "oci": ghcr.io/neoaggelos/cluster-api-provider-lxc/haproxy:v0.0.1
+                                - "oci": ghcr.io/lxc/cluster-api-provider-incus/haproxy:v20230606-42a2262b
                                 - "lxc": haproxy from the default simplestreams server
                             properties:
                               fingerprint:
@@ -192,7 +192,7 @@ spec:
                               Image to use for provisioning the load balancer machine. If not set,
                               a default image based on the load balancer type will be used.
 
-                                - "oci": ghcr.io/neoaggelos/cluster-api-provider-lxc/haproxy:v0.0.1
+                                - "oci": ghcr.io/lxc/cluster-api-provider-incus/haproxy:v20230606-42a2262b
                                 - "lxc": haproxy from the default simplestreams server
                             properties:
                               fingerprint:

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclustertemplates.yaml
@@ -134,7 +134,7 @@ spec:
                                       Image to use for provisioning the load balancer machine. If not set,
                                       a default image based on the load balancer type will be used.
 
-                                        - "oci": ghcr.io/neoaggelos/cluster-api-provider-lxc/haproxy:v0.0.1
+                                        - "oci": ghcr.io/lxc/cluster-api-provider-incus/haproxy:v20230606-42a2262b
                                         - "lxc": haproxy from the default simplestreams server
                                     properties:
                                       fingerprint:
@@ -213,7 +213,7 @@ spec:
                                       Image to use for provisioning the load balancer machine. If not set,
                                       a default image based on the load balancer type will be used.
 
-                                        - "oci": ghcr.io/neoaggelos/cluster-api-provider-lxc/haproxy:v0.0.1
+                                        - "oci": ghcr.io/lxc/cluster-api-provider-incus/haproxy:v20230606-42a2262b
                                         - "lxc": haproxy from the default simplestreams server
                                     properties:
                                       fingerprint:

--- a/docs/book/src/explanation/load-balancer.md
+++ b/docs/book/src/explanation/load-balancer.md
@@ -46,7 +46,7 @@ The `oci` load balancer type is similar to `lxc`. The only difference is that an
 
 The control plane endpoint of the cluster will be set to the IP address of the haproxy container. The haproxy container is a single-point-of-failure for accessing the control plane of the workload cluster, so it is not suitable for production deployments. However, it requires zero configuration, therefore it can be used for evaulation or development purposes.
 
-The load balancer instance can be configured through the `spec.loadBalancer.oci.instanceSpec` configuration fields. Unless a custom image source is set, the `ghcr.io/neoaggelos/cluster-api-provider-lxc/haproxy:v0.0.1` (mirror of `kindest/haproxy`) image will be used.
+The load balancer instance can be configured through the `spec.loadBalancer.oci.instanceSpec` configuration fields. Unless a custom image source is set, the `ghcr.io/lxc/cluster-api-provider-incus/haproxy:v20230606-42a2262b` (mirror of `kindest/haproxy`) image will be used.
 
 Support for OCI containers was first added in Incus 6.5. Using the `oci` load balancer type when the `oci_instance` API extension is not supported will raise an error during the LXCCluster provisioning process.
 

--- a/docs/book/src/reference/api/v1alpha2/api.md
+++ b/docs/book/src/reference/api/v1alpha2/api.md
@@ -221,7 +221,7 @@ LXCLoadBalancerExternal
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCCluster">LXCCluster</a>, 
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCCluster">LXCCluster</a>,
 <a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCClusterTemplateResource">LXCClusterTemplateResource</a>)
 </p>
 <p>
@@ -709,7 +709,7 @@ LXCMachineImageSource
 <p>Image to use for provisioning the load balancer machine. If not set,
 a default image based on the load balancer type will be used.</p>
 <ul>
-<li>&ldquo;oci&rdquo;: ghcr.io/neoaggelos/cluster-api-provider-lxc/haproxy:v0.0.1</li>
+<li>&ldquo;oci&rdquo;: ghcr.io/lxc/cluster-api-provider-incus/haproxy:v20230606-42a2262b</li>
 <li>&ldquo;lxc&rdquo;: haproxy from the default simplestreams server</li>
 </ul>
 </td>
@@ -918,7 +918,7 @@ LXCMachineStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCLoadBalancerMachineSpec">LXCLoadBalancerMachineSpec</a>, 
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCLoadBalancerMachineSpec">LXCLoadBalancerMachineSpec</a>,
 <a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCMachineSpec">LXCMachineSpec</a>)
 </p>
 <p>
@@ -992,7 +992,7 @@ string
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCMachine">LXCMachine</a>, 
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCMachine">LXCMachine</a>,
 <a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCMachineTemplateResource">LXCMachineTemplateResource</a>)
 </p>
 <p>

--- a/hack/regsync.yaml
+++ b/hack/regsync.yaml
@@ -1,10 +1,14 @@
-
+version: 1
 
 sync:
   - source: docker.io/kindest/haproxy:v20230606-42a2262b
-    target: ghcr.io/neoaggelos/cluster-api-provider-lxc/haproxy:v20230606-42a2262b
+    target: ghcr.io/lxc/cluster-api-provider-incus/haproxy:v20230606-42a2262b
     type: image
 
-  - source: docker.io/kindest/haproxy:v20230606-42a2262b
-    target: ghcr.io/neoaggelos/cluster-api-provider-lxc/haproxy:v0.0.1
+  - source: docker.io/kindest/local-path-helper:v20230510-486859a6
+    target: ghcr.io/lxc/cluster-api-provider-incus/local-path-helper:v20230510-486859a6
+    type: image
+
+  - source: docker.io/kindest/local-path-provisioner:v20240813-c6f155d6
+    target: ghcr.io/lxc/cluster-api-provider-incus/local-path-provisioner:v20240813-c6f155d6 
     type: image

--- a/internal/loadbalancer/manager_oci.go
+++ b/internal/loadbalancer/manager_oci.go
@@ -21,7 +21,7 @@ func defaultHaproxyOCIImage() api.InstanceSource {
 		Type:     "image",
 		Protocol: "oci",
 		Server:   "https://ghcr.io",
-		Alias:    "neoaggelos/cluster-api-provider-lxc/haproxy:v0.0.1",
+		Alias:    "lxc/cluster-api-provider-incus/haproxy:v20230606-42a2262b",
 	}
 }
 


### PR DESCRIPTION
### Summary

Stop relying on `ghcr.io/neoaggelos/cluster-api-provider-lxc/haproxy:v0.0.1` image.

Mirror kindest images for haproxy and local path provisioner under the `ghcr.io/lxc/cluster-api-provider-incus` namespace, and start using the haproxy image instead.
