### PR TITLE
Enable machine health checks in default clusterclass

### DIFF
--- a/templates/clusterclass-capn-default.yaml
+++ b/templates/clusterclass-capn-default.yaml
@@ -13,14 +13,14 @@ spec:
         kind: LXCMachineTemplate
         apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
         name: capn-default-control-plane
-    # machineHealthCheck:
-    #   unhealthyConditions:
-    #     - type: Ready
-    #       status: Unknown
-    #       timeout: 300s
-    #     - type: Ready
-    #       status: "False"
-    #       timeout: 300s
+    machineHealthCheck:
+      unhealthyConditions:
+        - type: Ready
+          status: Unknown
+          timeout: 300s
+        - type: Ready
+          status: "False"
+          timeout: 300s
   infrastructure:
     ref:
       apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
@@ -40,14 +40,14 @@ spec:
             apiVersion: infrastructure.cluster.x-k8s.io/v1alpha2
             kind: LXCMachineTemplate
             name: capn-default-default-worker
-      # machineHealthCheck:
-      #   unhealthyConditions:
-      #     - type: Ready
-      #       status: Unknown
-      #       timeout: 300s
-      #     - type: Ready
-      #       status: "False"
-      #       timeout: 300s
+      machineHealthCheck:
+        unhealthyConditions:
+          - type: Ready
+            status: Unknown
+            timeout: 300s
+          - type: Ready
+            status: "False"
+            timeout: 300s
   variables:
   - name: secretRef
     required: true


### PR DESCRIPTION
### Summary

Enable `MachineHealthChecks` for the default cluster class, since we offer an option to deploy a CNI out of the box