### PR TITLE
Use Kubernetes v1.33.0 in all cluster templates by default

### DIFF
--- a/templates/cluster-template-development.rc
+++ b/templates/cluster-template-development.rc
@@ -1,5 +1,5 @@
 # Cluster version and size
-export KUBERNETES_VERSION=v1.32.3
+export KUBERNETES_VERSION=v1.33.0
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 

--- a/templates/cluster-template-kube-vip.rc
+++ b/templates/cluster-template-kube-vip.rc
@@ -1,5 +1,5 @@
 # Cluster version and size
-export KUBERNETES_VERSION=v1.32.3
+export KUBERNETES_VERSION=v1.33.0
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 

--- a/templates/cluster-template-ovn.rc
+++ b/templates/cluster-template-ovn.rc
@@ -1,5 +1,5 @@
 # Cluster version and size
-export KUBERNETES_VERSION=v1.32.3
+export KUBERNETES_VERSION=v1.33.0
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 

--- a/templates/cluster-template-ubuntu.rc
+++ b/templates/cluster-template-ubuntu.rc
@@ -1,5 +1,5 @@
 # Cluster version and size
-export KUBERNETES_VERSION=v1.32.3
+export KUBERNETES_VERSION=v1.33.0
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 

--- a/templates/cluster-template.rc
+++ b/templates/cluster-template.rc
@@ -1,5 +1,5 @@
 ## Cluster version and size
-export KUBERNETES_VERSION=v1.32.3
+export KUBERNETES_VERSION=v1.33.0
 export CONTROL_PLANE_MACHINE_COUNT=1
 export WORKER_MACHINE_COUNT=1
 


### PR DESCRIPTION
### Summary

Use Kubernetes version `v1.33.0` in all example cluster template configurations.