### PR TITLE
Use a systemd service to bootstrap cloud-init in kind instances

### DIFF
--- a/internal/controller/lxcmachine/controller_util_launch.go
+++ b/internal/controller/lxcmachine/controller_util_launch.go
@@ -127,7 +127,7 @@ func launchInstance(ctx context.Context, cluster *clusterv1.Cluster, lxcCluster 
 		maps.Copy(instance.Config, profile.Config)
 	}
 
-	return lxcClient.WithTarget(lxcMachine.Spec.Target).WaitForLaunchInstance(ctx, instance, defaultSeedFiles)
+	return lxcClient.WithTarget(lxcMachine.Spec.Target).WaitForLaunchInstance(ctx, instance, &lxc.LaunchOptions{SeedFiles: defaultSeedFiles})
 }
 
 // defaultSeedFiles that are injected to LXCMachine instances.

--- a/internal/lxc/client_instances_util.go
+++ b/internal/lxc/client_instances_util.go
@@ -59,3 +59,27 @@ func (c *Client) waitForInstanceAddress(ctx context.Context, name string) ([]str
 		}
 	}
 }
+
+// LaunchOptions describe additional provisioning actions for machines.
+type LaunchOptions struct {
+	// SeedFiles are "<file>"="<contents>" template files that will be created on the machine.
+	// Supported by all instance types.
+	SeedFiles map[string]string
+	// Symlinks are "<path>"="<target>" symbolic links to that will be created on the machine.
+	// Not supported by virtual-machine instance types.
+	Symlinks map[string]string
+}
+
+func (o *LaunchOptions) GetSeedFiles() map[string]string {
+	if o == nil {
+		return nil
+	}
+	return o.SeedFiles
+}
+
+func (o *LaunchOptions) GetSymlinks() map[string]string {
+	if o == nil {
+		return nil
+	}
+	return o.Symlinks
+}

--- a/internal/static/embed/cloud-init-launch.service
+++ b/internal/static/embed/cloud-init-launch.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=CAPN cloud-init launcher
+After=network.target
+ConditionPathExists=!/hack/cloud-init.success
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/env python3 /hack/cloud-init.py
+ExecStartPost=/usr/bin/touch /hack/cloud-init.success
+Restart=on-failure
+RestartSec=5s
+StartLimitInterval=60
+StartLimitBurst=10
+
+[Install]
+WantedBy=multi-user.target

--- a/internal/static/scripts.go
+++ b/internal/static/scripts.go
@@ -26,6 +26,9 @@ var (
 
 	//go:embed embed/user-data
 	cloudInitUserDataTemplate string
+
+	//go:embed embed/cloud-init-launch.service
+	cloudInitLaunchSystemdServiceTemplate string
 )
 
 func InstallKubeadmScript() string {
@@ -58,4 +61,8 @@ func CloudInitMetaDataTemplate() string {
 
 func CloudInitUserDataTemplate() string {
 	return cloudInitUserDataTemplate
+}
+
+func CloudInitLaunchSystemdServiceTemplate() string {
+	return cloudInitLaunchSystemdServiceTemplate
 }


### PR DESCRIPTION
### Summary

#102 added support for kind instance types, which do not come with cloud-init preinstalled. Use a systemd service instead of running the cloud-init command manually.

### Changes

- Introduce machinery to configure template files as well as symlinks for instances
- Add a `cloud-init-launch.service` on kind instances, and use a symlink to auto-enable it
- The `/hack/cloud-init.py` now runs once (due to the condition path file) when the instance starts.