### PR TITLE
Fix launching instances with custom image

### DIFF
--- a/internal/controller/lxcmachine/controller_util_launch.go
+++ b/internal/controller/lxcmachine/controller_util_launch.go
@@ -58,7 +58,13 @@ func launchInstance(ctx context.Context, cluster *clusterv1.Cluster, lxcCluster 
 		}
 	}
 
-	var image api.InstanceSource
+	image := api.InstanceSource{
+		Type:        "image",
+		Protocol:    lxcMachine.Spec.Image.Protocol,
+		Server:      lxcMachine.Spec.Image.Server,
+		Alias:       lxcMachine.Spec.Image.Name,
+		Fingerprint: lxcMachine.Spec.Image.Fingerprint,
+	}
 	switch {
 	case lxcMachine.Spec.Image.Name != "":
 		source, parsed, err := lxcClient.TryParseImageSource(ctx, lxcMachine.Spec.Image.Name)
@@ -87,14 +93,6 @@ func launchInstance(ctx context.Context, cluster *clusterv1.Cluster, lxcCluster 
 			Protocol: "simplestreams",
 			Server:   lxc.DefaultSimplestreamsServer,
 			Alias:    fmt.Sprintf("kubeadm/%s", version),
-		}
-	default:
-		image = api.InstanceSource{
-			Type:        "image",
-			Protocol:    lxcMachine.Spec.Image.Protocol,
-			Server:      lxcMachine.Spec.Image.Server,
-			Alias:       lxcMachine.Spec.Image.Name,
-			Fingerprint: lxcMachine.Spec.Image.Fingerprint,
 		}
 	}
 

--- a/internal/controller/lxcmachine/controller_util_launch_kind.go
+++ b/internal/controller/lxcmachine/controller_util_launch_kind.go
@@ -55,9 +55,14 @@ func launchKindInstance(ctx context.Context, cluster *clusterv1.Cluster, lxcClus
 		}
 	}
 
-	var image api.InstanceSource
-	switch {
-	case lxcMachine.Spec.Image.IsZero():
+	image := api.InstanceSource{
+		Type:        "image",
+		Protocol:    lxcMachine.Spec.Image.Protocol,
+		Server:      lxcMachine.Spec.Image.Server,
+		Alias:       lxcMachine.Spec.Image.Name,
+		Fingerprint: lxcMachine.Spec.Image.Fingerprint,
+	}
+	if lxcMachine.Spec.Image.IsZero() {
 		if machine.Spec.Version == nil {
 			return nil, utils.TerminalError(fmt.Errorf("no image source specified on LXCMachineTemplate and Machine %q does not have a Kubernetes version", machine.Name))
 		}
@@ -82,14 +87,6 @@ func launchKindInstance(ctx context.Context, cluster *clusterv1.Cluster, lxcClus
 			Protocol: "oci",
 			Server:   "https://docker.io",
 			Alias:    fmt.Sprintf("kindest/node:%s", version),
-		}
-	default:
-		image = api.InstanceSource{
-			Type:        "image",
-			Protocol:    lxcMachine.Spec.Image.Protocol,
-			Server:      lxcMachine.Spec.Image.Server,
-			Alias:       lxcMachine.Spec.Image.Name,
-			Fingerprint: lxcMachine.Spec.Image.Fingerprint,
 		}
 	}
 


### PR DESCRIPTION
### Summary

Address regression introduced by #112. If the image is not parsed, then the InstanceSource.Type was not getting set to `image`, causing errors like:

```
failed to CreateInstace: invalid instance source type ""
```