### PR TITLE
Improvements to handling of image name

### DIFF
--- a/api/v1alpha2/lxcmachine_types.go
+++ b/api/v1alpha2/lxcmachine_types.go
@@ -127,19 +127,26 @@ type LXCMachineImageSource struct {
 	// Name is the image name or alias.
 	//
 	// Note that Incus and Canonical LXD use incompatible image servers. To help
-	// mitigate this issue, the following image names are automatically recognized:
+	// mitigate this issue, the following image names are recognized:
 	//
-	//   - "ubuntu:VERSION" (e.g. "ubuntu:24.04")
-	//     - Incus: "images:ubuntu/VERSION/cloud" (from https://images.linuxcontainers.org)
-	//     - LXD: 	"ubuntu:VERSION" (from https://cloud-images.ubuntu.com/releases)
+	// For Incus:
 	//
-	//   - "debian:VERSION" (e.g. "debian:12")
-	//     - Incus: "images:debian/VERSION/cloud" (from https://images.linuxcontainers.org)
-	//     - LXD: 	"images:debian/VERSION/cloud" (from https://images.lxd.canonical.com)
+	//   - "ubuntu:VERSION" => "ubuntu/VERSION/cloud" from https://images.linuxcontainers.org
+	//   - "debian:VERSION" => "debian/VERSION/cloud" from https://images.linuxcontainers.org
+	//   - "images:IMAGE" => "IMAGE" from https://images.linuxcontainers.org
+	//   - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
+	//   - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
 	//
-	//   - "images:IMAGE" (e.g. "images:almalinux/9/cloud")
-	//     - Incus: "images:IMAGE" (from https://images.linuxcontainers.org)
-	//     - LXD: 	"images:IMAGE" (from https://images.lxd.canonical.com)
+	// For LXD:
+	//
+	//   - "ubuntu:VERSION" => "VERSION" from https://cloud-images.ubuntu.com/releases
+	//   - "debian:VERSION" => "debian/VERSION/cloud" from https://images.lxd.canonical.com
+	//   - "images:IMAGE" => "IMAGE" from https://images.lxd.canonical.com
+	//   - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
+	//   - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+	//
+	// Any instances of "VERSION" in the image name will be replaced with the machine version.
+	// For example, to use debian based kubeadm images, you can set image name to "capi:kubeadm/VERSION/debian"
 	//
 	// +optional
 	Name string `json:"name"`

--- a/cmd/exp/image-builder/run_stage_create_instance.go
+++ b/cmd/exp/image-builder/run_stage_create_instance.go
@@ -17,7 +17,7 @@ func (*stageCreateInstance) name() string { return "create-instance" }
 // incus launch image:ubuntu/24.04/cloud
 // incus launch image:ubuntu/24.04/cloud --vm -d root,size=5GiB
 func (*stageCreateInstance) run(ctx context.Context) error {
-	image, _, err := lxcClient.TryParseImageSource(ctx, cfg.baseImage)
+	image, _, err := lxc.TryParseImageSource(lxcClient.GetServerName(), cfg.baseImage)
 	if err != nil {
 		return fmt.Errorf("failed to pick image source for base image %q: %w", cfg.baseImage, err)
 	}

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclusters.yaml
@@ -121,20 +121,30 @@ spec:
                                 description: Fingerprint is the image fingerprint.
                                 type: string
                               name:
-                                description: "Name is the image name or alias.\n\nNote
-                                  that Incus and Canonical LXD use incompatible image
-                                  servers. To help\nmitigate this issue, the following
-                                  image names are automatically recognized:\n\n  -
-                                  \"ubuntu:VERSION\" (e.g. \"ubuntu:24.04\")\n    -
-                                  Incus: \"images:ubuntu/VERSION/cloud\" (from https://images.linuxcontainers.org)\n
-                                  \   - LXD: \t\"ubuntu:VERSION\" (from https://cloud-images.ubuntu.com/releases)\n\n
-                                  \ - \"debian:VERSION\" (e.g. \"debian:12\")\n    -
-                                  Incus: \"images:debian/VERSION/cloud\" (from https://images.linuxcontainers.org)\n
-                                  \   - LXD: \t\"images:debian/VERSION/cloud\" (from
-                                  https://images.lxd.canonical.com)\n\n  - \"images:IMAGE\"
-                                  (e.g. \"images:almalinux/9/cloud\")\n    - Incus:
-                                  \"images:IMAGE\" (from https://images.linuxcontainers.org)\n
-                                  \   - LXD: \t\"images:IMAGE\" (from https://images.lxd.canonical.com)"
+                                description: |-
+                                  Name is the image name or alias.
+
+                                  Note that Incus and Canonical LXD use incompatible image servers. To help
+                                  mitigate this issue, the following image names are recognized:
+
+                                  For Incus:
+
+                                    - "ubuntu:VERSION" => "ubuntu/VERSION/cloud" from https://images.linuxcontainers.org
+                                    - "debian:VERSION" => "debian/VERSION/cloud" from https://images.linuxcontainers.org
+                                    - "images:IMAGE" => "IMAGE" from https://images.linuxcontainers.org
+                                    - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
+                                    - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+
+                                  For LXD:
+
+                                    - "ubuntu:VERSION" => "VERSION" from https://cloud-images.ubuntu.com/releases
+                                    - "debian:VERSION" => "debian/VERSION/cloud" from https://images.lxd.canonical.com
+                                    - "images:IMAGE" => "IMAGE" from https://images.lxd.canonical.com
+                                    - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
+                                    - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+
+                                  Any instances of "VERSION" in the image name will be replaced with the machine version.
+                                  For example, to use debian based kubeadm images, you can set image name to "capi:kubeadm/VERSION/debian"
                                 type: string
                               protocol:
                                 description: Protocol is the protocol to use for fetching
@@ -204,20 +214,30 @@ spec:
                                 description: Fingerprint is the image fingerprint.
                                 type: string
                               name:
-                                description: "Name is the image name or alias.\n\nNote
-                                  that Incus and Canonical LXD use incompatible image
-                                  servers. To help\nmitigate this issue, the following
-                                  image names are automatically recognized:\n\n  -
-                                  \"ubuntu:VERSION\" (e.g. \"ubuntu:24.04\")\n    -
-                                  Incus: \"images:ubuntu/VERSION/cloud\" (from https://images.linuxcontainers.org)\n
-                                  \   - LXD: \t\"ubuntu:VERSION\" (from https://cloud-images.ubuntu.com/releases)\n\n
-                                  \ - \"debian:VERSION\" (e.g. \"debian:12\")\n    -
-                                  Incus: \"images:debian/VERSION/cloud\" (from https://images.linuxcontainers.org)\n
-                                  \   - LXD: \t\"images:debian/VERSION/cloud\" (from
-                                  https://images.lxd.canonical.com)\n\n  - \"images:IMAGE\"
-                                  (e.g. \"images:almalinux/9/cloud\")\n    - Incus:
-                                  \"images:IMAGE\" (from https://images.linuxcontainers.org)\n
-                                  \   - LXD: \t\"images:IMAGE\" (from https://images.lxd.canonical.com)"
+                                description: |-
+                                  Name is the image name or alias.
+
+                                  Note that Incus and Canonical LXD use incompatible image servers. To help
+                                  mitigate this issue, the following image names are recognized:
+
+                                  For Incus:
+
+                                    - "ubuntu:VERSION" => "ubuntu/VERSION/cloud" from https://images.linuxcontainers.org
+                                    - "debian:VERSION" => "debian/VERSION/cloud" from https://images.linuxcontainers.org
+                                    - "images:IMAGE" => "IMAGE" from https://images.linuxcontainers.org
+                                    - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
+                                    - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+
+                                  For LXD:
+
+                                    - "ubuntu:VERSION" => "VERSION" from https://cloud-images.ubuntu.com/releases
+                                    - "debian:VERSION" => "debian/VERSION/cloud" from https://images.lxd.canonical.com
+                                    - "images:IMAGE" => "IMAGE" from https://images.lxd.canonical.com
+                                    - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
+                                    - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+
+                                  Any instances of "VERSION" in the image name will be replaced with the machine version.
+                                  For example, to use debian based kubeadm images, you can set image name to "capi:kubeadm/VERSION/debian"
                                 type: string
                               protocol:
                                 description: Protocol is the protocol to use for fetching

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclustertemplates.yaml
@@ -141,22 +141,30 @@ spec:
                                         description: Fingerprint is the image fingerprint.
                                         type: string
                                       name:
-                                        description: "Name is the image name or alias.\n\nNote
-                                          that Incus and Canonical LXD use incompatible
-                                          image servers. To help\nmitigate this issue,
-                                          the following image names are automatically
-                                          recognized:\n\n  - \"ubuntu:VERSION\" (e.g.
-                                          \"ubuntu:24.04\")\n    - Incus: \"images:ubuntu/VERSION/cloud\"
-                                          (from https://images.linuxcontainers.org)\n
-                                          \   - LXD: \t\"ubuntu:VERSION\" (from https://cloud-images.ubuntu.com/releases)\n\n
-                                          \ - \"debian:VERSION\" (e.g. \"debian:12\")\n
-                                          \   - Incus: \"images:debian/VERSION/cloud\"
-                                          (from https://images.linuxcontainers.org)\n
-                                          \   - LXD: \t\"images:debian/VERSION/cloud\"
-                                          (from https://images.lxd.canonical.com)\n\n
-                                          \ - \"images:IMAGE\" (e.g. \"images:almalinux/9/cloud\")\n
-                                          \   - Incus: \"images:IMAGE\" (from https://images.linuxcontainers.org)\n
-                                          \   - LXD: \t\"images:IMAGE\" (from https://images.lxd.canonical.com)"
+                                        description: |-
+                                          Name is the image name or alias.
+
+                                          Note that Incus and Canonical LXD use incompatible image servers. To help
+                                          mitigate this issue, the following image names are recognized:
+
+                                          For Incus:
+
+                                            - "ubuntu:VERSION" => "ubuntu/VERSION/cloud" from https://images.linuxcontainers.org
+                                            - "debian:VERSION" => "debian/VERSION/cloud" from https://images.linuxcontainers.org
+                                            - "images:IMAGE" => "IMAGE" from https://images.linuxcontainers.org
+                                            - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
+                                            - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+
+                                          For LXD:
+
+                                            - "ubuntu:VERSION" => "VERSION" from https://cloud-images.ubuntu.com/releases
+                                            - "debian:VERSION" => "debian/VERSION/cloud" from https://images.lxd.canonical.com
+                                            - "images:IMAGE" => "IMAGE" from https://images.lxd.canonical.com
+                                            - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
+                                            - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+
+                                          Any instances of "VERSION" in the image name will be replaced with the machine version.
+                                          For example, to use debian based kubeadm images, you can set image name to "capi:kubeadm/VERSION/debian"
                                         type: string
                                       protocol:
                                         description: Protocol is the protocol to use
@@ -227,22 +235,30 @@ spec:
                                         description: Fingerprint is the image fingerprint.
                                         type: string
                                       name:
-                                        description: "Name is the image name or alias.\n\nNote
-                                          that Incus and Canonical LXD use incompatible
-                                          image servers. To help\nmitigate this issue,
-                                          the following image names are automatically
-                                          recognized:\n\n  - \"ubuntu:VERSION\" (e.g.
-                                          \"ubuntu:24.04\")\n    - Incus: \"images:ubuntu/VERSION/cloud\"
-                                          (from https://images.linuxcontainers.org)\n
-                                          \   - LXD: \t\"ubuntu:VERSION\" (from https://cloud-images.ubuntu.com/releases)\n\n
-                                          \ - \"debian:VERSION\" (e.g. \"debian:12\")\n
-                                          \   - Incus: \"images:debian/VERSION/cloud\"
-                                          (from https://images.linuxcontainers.org)\n
-                                          \   - LXD: \t\"images:debian/VERSION/cloud\"
-                                          (from https://images.lxd.canonical.com)\n\n
-                                          \ - \"images:IMAGE\" (e.g. \"images:almalinux/9/cloud\")\n
-                                          \   - Incus: \"images:IMAGE\" (from https://images.linuxcontainers.org)\n
-                                          \   - LXD: \t\"images:IMAGE\" (from https://images.lxd.canonical.com)"
+                                        description: |-
+                                          Name is the image name or alias.
+
+                                          Note that Incus and Canonical LXD use incompatible image servers. To help
+                                          mitigate this issue, the following image names are recognized:
+
+                                          For Incus:
+
+                                            - "ubuntu:VERSION" => "ubuntu/VERSION/cloud" from https://images.linuxcontainers.org
+                                            - "debian:VERSION" => "debian/VERSION/cloud" from https://images.linuxcontainers.org
+                                            - "images:IMAGE" => "IMAGE" from https://images.linuxcontainers.org
+                                            - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
+                                            - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+
+                                          For LXD:
+
+                                            - "ubuntu:VERSION" => "VERSION" from https://cloud-images.ubuntu.com/releases
+                                            - "debian:VERSION" => "debian/VERSION/cloud" from https://images.lxd.canonical.com
+                                            - "images:IMAGE" => "IMAGE" from https://images.lxd.canonical.com
+                                            - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
+                                            - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+
+                                          Any instances of "VERSION" in the image name will be replaced with the machine version.
+                                          For example, to use debian based kubeadm images, you can set image name to "capi:kubeadm/VERSION/debian"
                                         type: string
                                       protocol:
                                         description: Protocol is the protocol to use

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcmachines.yaml
@@ -118,18 +118,30 @@ spec:
                     description: Fingerprint is the image fingerprint.
                     type: string
                   name:
-                    description: "Name is the image name or alias.\n\nNote that Incus
-                      and Canonical LXD use incompatible image servers. To help\nmitigate
-                      this issue, the following image names are automatically recognized:\n\n
-                      \ - \"ubuntu:VERSION\" (e.g. \"ubuntu:24.04\")\n    - Incus:
-                      \"images:ubuntu/VERSION/cloud\" (from https://images.linuxcontainers.org)\n
-                      \   - LXD: \t\"ubuntu:VERSION\" (from https://cloud-images.ubuntu.com/releases)\n\n
-                      \ - \"debian:VERSION\" (e.g. \"debian:12\")\n    - Incus: \"images:debian/VERSION/cloud\"
-                      (from https://images.linuxcontainers.org)\n    - LXD: \t\"images:debian/VERSION/cloud\"
-                      (from https://images.lxd.canonical.com)\n\n  - \"images:IMAGE\"
-                      (e.g. \"images:almalinux/9/cloud\")\n    - Incus: \"images:IMAGE\"
-                      (from https://images.linuxcontainers.org)\n    - LXD: \t\"images:IMAGE\"
-                      (from https://images.lxd.canonical.com)"
+                    description: |-
+                      Name is the image name or alias.
+
+                      Note that Incus and Canonical LXD use incompatible image servers. To help
+                      mitigate this issue, the following image names are recognized:
+
+                      For Incus:
+
+                        - "ubuntu:VERSION" => "ubuntu/VERSION/cloud" from https://images.linuxcontainers.org
+                        - "debian:VERSION" => "debian/VERSION/cloud" from https://images.linuxcontainers.org
+                        - "images:IMAGE" => "IMAGE" from https://images.linuxcontainers.org
+                        - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
+                        - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+
+                      For LXD:
+
+                        - "ubuntu:VERSION" => "VERSION" from https://cloud-images.ubuntu.com/releases
+                        - "debian:VERSION" => "debian/VERSION/cloud" from https://images.lxd.canonical.com
+                        - "images:IMAGE" => "IMAGE" from https://images.lxd.canonical.com
+                        - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
+                        - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+
+                      Any instances of "VERSION" in the image name will be replaced with the machine version.
+                      For example, to use debian based kubeadm images, you can set image name to "capi:kubeadm/VERSION/debian"
                     type: string
                   protocol:
                     description: Protocol is the protocol to use for fetching the

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcmachinetemplates.yaml
@@ -133,19 +133,30 @@ spec:
                             description: Fingerprint is the image fingerprint.
                             type: string
                           name:
-                            description: "Name is the image name or alias.\n\nNote
-                              that Incus and Canonical LXD use incompatible image
-                              servers. To help\nmitigate this issue, the following
-                              image names are automatically recognized:\n\n  - \"ubuntu:VERSION\"
-                              (e.g. \"ubuntu:24.04\")\n    - Incus: \"images:ubuntu/VERSION/cloud\"
-                              (from https://images.linuxcontainers.org)\n    - LXD:
-                              \t\"ubuntu:VERSION\" (from https://cloud-images.ubuntu.com/releases)\n\n
-                              \ - \"debian:VERSION\" (e.g. \"debian:12\")\n    - Incus:
-                              \"images:debian/VERSION/cloud\" (from https://images.linuxcontainers.org)\n
-                              \   - LXD: \t\"images:debian/VERSION/cloud\" (from https://images.lxd.canonical.com)\n\n
-                              \ - \"images:IMAGE\" (e.g. \"images:almalinux/9/cloud\")\n
-                              \   - Incus: \"images:IMAGE\" (from https://images.linuxcontainers.org)\n
-                              \   - LXD: \t\"images:IMAGE\" (from https://images.lxd.canonical.com)"
+                            description: |-
+                              Name is the image name or alias.
+
+                              Note that Incus and Canonical LXD use incompatible image servers. To help
+                              mitigate this issue, the following image names are recognized:
+
+                              For Incus:
+
+                                - "ubuntu:VERSION" => "ubuntu/VERSION/cloud" from https://images.linuxcontainers.org
+                                - "debian:VERSION" => "debian/VERSION/cloud" from https://images.linuxcontainers.org
+                                - "images:IMAGE" => "IMAGE" from https://images.linuxcontainers.org
+                                - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
+                                - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+
+                              For LXD:
+
+                                - "ubuntu:VERSION" => "VERSION" from https://cloud-images.ubuntu.com/releases
+                                - "debian:VERSION" => "debian/VERSION/cloud" from https://images.lxd.canonical.com
+                                - "images:IMAGE" => "IMAGE" from https://images.lxd.canonical.com
+                                - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
+                                - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+
+                              Any instances of "VERSION" in the image name will be replaced with the machine version.
+                              For example, to use debian based kubeadm images, you can set image name to "capi:kubeadm/VERSION/debian"
                             type: string
                           protocol:
                             description: Protocol is the protocol to use for fetching

--- a/internal/lxc/client_discovery.go
+++ b/internal/lxc/client_discovery.go
@@ -1,7 +1,6 @@
 package lxc
 
 import (
-	"context"
 	"fmt"
 	"slices"
 	"strings"
@@ -12,7 +11,7 @@ import (
 )
 
 // GetServerName returns one of "incus", "lxd" or "unknown", depending on the server type.
-func (c *Client) GetServerName(ctx context.Context) string {
+func (c *Client) GetServerName() string {
 	switch c.serverInfo.Environment.Server {
 	case Incus, LXD:
 		return c.serverInfo.Environment.Server

--- a/internal/lxc/client_parse_image_test.go
+++ b/internal/lxc/client_parse_image_test.go
@@ -1,0 +1,69 @@
+package lxc_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/lxc/incus/v6/shared/api"
+
+	"github.com/lxc/cluster-api-provider-incus/internal/lxc"
+
+	. "github.com/onsi/gomega"
+)
+
+func simplestreamsImage(server string, name string) api.InstanceSource {
+	return api.InstanceSource{
+		Type:     "image",
+		Protocol: "simplestreams",
+		Server:   server,
+		Alias:    name,
+	}
+}
+
+func TestTryParseImageSource(t *testing.T) {
+	for _, tc := range []struct {
+		server            string
+		image             string
+		expectErr         bool
+		expectParsed      bool
+		expectImageSource api.InstanceSource
+	}{
+		// verify incus prefixes
+		{server: "incus", image: "image-name"},
+		{server: "incus", image: "unknown:image", expectErr: true},
+		{server: "incus", image: "ubuntu:24.04", expectParsed: true, expectImageSource: simplestreamsImage("https://images.linuxcontainers.org", "ubuntu/24.04/cloud")},
+		{server: "incus", image: "debian:12", expectParsed: true, expectImageSource: simplestreamsImage("https://images.linuxcontainers.org", "debian/12/cloud")},
+		{server: "incus", image: "images:almalinux/9/cloud", expectParsed: true, expectImageSource: simplestreamsImage("https://images.linuxcontainers.org", "almalinux/9/cloud")},
+		{server: "incus", image: "capi:kubeadm/v1.33.0", expectParsed: true, expectImageSource: simplestreamsImage("https://d14dnvi2l3tc5t.cloudfront.net", "kubeadm/v1.33.0")},
+		{server: "incus", image: "capi-stg:kubeadm/v1.33.0", expectParsed: true, expectImageSource: simplestreamsImage("https://djapqxqu5n2qu.cloudfront.net", "kubeadm/v1.33.0")},
+		// verify lxd prefixes
+		{server: "lxd", image: "image-name"},
+		{server: "lxd", image: "unknown:image", expectErr: true},
+		{server: "lxd", image: "ubuntu:24.04", expectParsed: true, expectImageSource: simplestreamsImage("https://cloud-images.ubuntu.com/releases/", "24.04")},
+		{server: "lxd", image: "debian:12", expectParsed: true, expectImageSource: simplestreamsImage("https://images.lxd.canonical.com", "debian/12/cloud")},
+		{server: "lxd", image: "images:almalinux/9/cloud", expectParsed: true, expectImageSource: simplestreamsImage("https://images.lxd.canonical.com", "almalinux/9/cloud")},
+		{server: "lxd", image: "capi:kubeadm/v1.33.0", expectParsed: true, expectImageSource: simplestreamsImage("https://d14dnvi2l3tc5t.cloudfront.net", "kubeadm/v1.33.0")},
+		{server: "lxd", image: "capi-stg:kubeadm/v1.33.0", expectParsed: true, expectImageSource: simplestreamsImage("https://djapqxqu5n2qu.cloudfront.net", "kubeadm/v1.33.0")},
+		// verify prefixes for unknown
+		{server: "unknown", image: "image-name"},
+		{server: "unknown", image: "ubuntu:24.04", expectErr: true},
+	} {
+		t.Run(fmt.Sprintf("%s/%s", tc.server, tc.image), func(t *testing.T) {
+			g := NewWithT(t)
+
+			image, parsed, err := lxc.TryParseImageSource(tc.server, tc.image)
+			if tc.expectErr {
+				g.Expect(err).To(HaveOccurred())
+				return
+			}
+
+			g.Expect(err).ToNot(HaveOccurred())
+			if !tc.expectParsed {
+				g.Expect(parsed).To(BeFalse())
+				return
+			}
+
+			g.Expect(image).To(Equal(tc.expectImageSource))
+		})
+	}
+}

--- a/internal/lxc/consts.go
+++ b/internal/lxc/consts.go
@@ -6,6 +6,18 @@ const (
 	// DefaultSimplestreamsServer is the default simplestreams server for fetching images.
 	DefaultSimplestreamsServer = "https://d14dnvi2l3tc5t.cloudfront.net"
 
+	// DefaultStagingSimplestreamsServer is the default staging simplestreams server for fetching images.
+	DefaultStagingSimplestreamsServer = "https://djapqxqu5n2qu.cloudfront.net"
+
+	// DefaultIncusSimplestreamsServer is the default simplestreams server for Incus.
+	DefaultIncusSimplestreamsServer = "https://images.linuxcontainers.org"
+
+	// DefaultLXDSimplestreamsServer is the default simplestreams server for Canonical LXD.
+	DefaultLXDSimplestreamsServer = "https://images.lxd.canonical.com"
+
+	// DefaultLXDUbuntuSimplestreamsServer is the default simplestreams server for Ubuntu images for Canonical LXD.
+	DefaultLXDUbuntuSimplestreamsServer = "https://cloud-images.ubuntu.com/releases/"
+
 	// Container is the instance type for container instances.
 	Container = "container"
 


### PR DESCRIPTION
### Summary

- replace VERSION with machine version
- add "capi" and "capi-stg" prefixes
- add unit tests for well known image prefixes parsing