### PR TITLE
API documentation and links

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,18 +17,18 @@ The provider can be used in single-node development environments for evaluation 
 
 ## Documentation
 
-Please refer to our [book](https://lxc.github.io/cluster-api-provider-incus) for in-depth documentation.
+Please refer to our [book](https://capn.linuxcontainers.org) for in-depth documentation.
 
 ## Quick Start
 
-See [Quick Start](https://lxc.github.io/cluster-api-provider-incus/tutorial/quick-start.html) to launch a cluster on a single-node development environment.
+See [Quick Start](https://capn.linuxcontainers.org/tutorial/quick-start.html) to launch a cluster on a single-node development environment.
 
 ## Features
 
 - Supports [Incus](https://linuxcontainers.org/incus/introduction/), [Canonical LXD](https://canonical.com/lxd) and [Canonical MicroCloud](https://canonical.com/microcloud).
-- Support for [kube-vip](https://lxc.github.io/cluster-api-provider-incus/reference/templates/kube-vip.html) (production), [OVN network load balancers](https://lxc.github.io/cluster-api-provider-incus/reference/templates/ovn.html) or simple [haproxy containers](https://lxc.github.io/cluster-api-provider-incus/reference/templates/development.html) (development) for the cluster load balancer.
-- [Default simplestreams server](https://lxc.github.io/cluster-api-provider-incus/reference/default-simplestreams-server.html) with pre-built kubeadm images.
-- Supports virtual machines or LXC containers for the cluster machines. Automatically manages the [profile](https://lxc.github.io/cluster-api-provider-incus/reference/profile/kubeadm.html) for Kubernetes to work in LXC containers.
+- Support for [kube-vip](https://capn.linuxcontainers.org/reference/templates/kube-vip.html) (production), [OVN network load balancers](https://capn.linuxcontainers.org/reference/templates/ovn.html) or simple [haproxy containers](https://capn.linuxcontainers.org/reference/templates/development.html) (development) for the cluster load balancer.
+- [Default simplestreams server](https://capn.linuxcontainers.org/reference/default-simplestreams-server.html) with pre-built kubeadm images.
+- Supports virtual machines or LXC containers for the cluster machines. Automatically manages the [profile](https://capn.linuxcontainers.org/reference/profile/kubeadm.html) for Kubernetes to work in LXC containers.
 - Can be used for local development similar to CAPD for quickly iterating on custom bootstrap and control-plane providers, e.g. K3s, Canonical Kubernetes, etc.
 
 ## Project Roadmap
@@ -76,4 +76,4 @@ The `cluster-api-provider-incus` project would love your suggestions, contributi
 
 Remember that there are numerous effective ways to contribute to the project: raise a pull request to fix a bug, improve test coverage, improve existing documentation or even participate in GitHub issues. We want your help!
 
-Please refer to the [developer guide](https://lxc.github.io/cluster-api-provider-incus/howto/developer-guide.html) in order to get started with setting up a local environment for development and testing.
+Please refer to the [developer guide](https://capn.linuxcontainers.org/howto/developer-guide.html) in order to get started with setting up a local environment for development and testing.

--- a/api/v1alpha2/lxccluster_types.go
+++ b/api/v1alpha2/lxccluster_types.go
@@ -58,7 +58,7 @@ type LXCClusterSpec struct {
 	// LXCMachineTemplate objects.
 	//
 	// For more details on the default kubeadm profile that is applied, see
-	// https://lxc.github.io/cluster-api-provider-incus/reference/profile/kubeadm.html
+	// https://capn.linuxcontainers.org/reference/profile/kubeadm.html
 	//
 	// +optional
 	SkipDefaultKubeadmProfile bool `json:"skipDefaultKubeadmProfile"`

--- a/api/v1alpha2/lxccluster_types.go
+++ b/api/v1alpha2/lxccluster_types.go
@@ -97,7 +97,7 @@ type LXCClusterLoadBalancer struct {
 	//
 	// The load balancer container is a single point of failure to access the workload cluster control plane. Therefore, it should only be used for development or evaluation clusters.
 	//
-	// Requires server extensions: "instance_oci"
+	// Requires server extensions: `instance_oci`
 	//
 	// +optional
 	OCI *LXCLoadBalancerInstance `json:"oci,omitempty"`
@@ -110,7 +110,7 @@ type LXCClusterLoadBalancer struct {
 	//
 	// When using the "ovn" mode, the load balancer address must be set in `.spec.controlPlaneEndpoint.host` on the LXCCluster object.
 	//
-	// Requires server extensions: "network_load_balancer", "network_load_balancer_health_checks"
+	// Requires server extensions: `network_load_balancer`, `network_load_balancer_health_checks`
 	//
 	// +optional
 	OVN *LXCLoadBalancerOVN `json:"ovn,omitempty"`

--- a/api/v1alpha2/lxcmachine_types.go
+++ b/api/v1alpha2/lxcmachine_types.go
@@ -40,10 +40,10 @@ type LXCMachineSpec struct {
 	// +optional
 	ProviderID *string `json:"providerID,omitempty"`
 
-	// InstanceType is "container" or "virtual-machine". Empty defaults to "container".
+	// InstanceType is `container` or `virtual-machine`. Empty defaults to `container`.
 	//
-	// InstanceType may also be set to "kind", in which case OCI containers using the kindest/node
-	// images will be created. This requires server extensions: "instance_oci", "instance_oci_entrypoint".
+	// InstanceType may also be set to `kind`, in which case OCI containers using the kindest/node
+	// images will be created. This requires server extensions: `instance_oci`, `instance_oci_entrypoint`.
 	//
 	// +kubebuilder:validation:Enum:=container;virtual-machine;kind;""
 	// +optional
@@ -71,9 +71,9 @@ type LXCMachineSpec struct {
 	// For example, to specify a different network for an instance, you can use:
 	//
 	// ```yaml
-	//   # override device "eth0", to be of type "nic" and use network "my-network"
-	//   devices:
-	//   - eth0,type=nic,network=my-network
+	// # override device "eth0", to be of type "nic" and use network "my-network"
+	// devices:
+	// - eth0,type=nic,network=my-network
 	// ```
 	//
 	// +optional
@@ -83,11 +83,11 @@ type LXCMachineSpec struct {
 	//
 	// Note that the provider will always set the following configuration keys:
 	//
-	// - "cloud-init.user-data": cloud-init config data
-	// - "user.cluster-name": name of owning cluster
-	// - "user.cluster-namespace": namespace of owning cluster
-	// - "user.cluster-role": instance role (e.g. control-plane, worker)
-	// - "user.machine-name": name of machine (should match instance hostname)
+	// - `cloud-init.user-data`: cloud-init config data
+	// - `user.cluster-name`: name of owning cluster
+	// - `user.cluster-namespace`: namespace of owning cluster
+	// - `user.cluster-role`: instance role (e.g. control-plane, worker)
+	// - `user.machine-name`: name of machine (should match instance hostname)
 	//
 	// See https://linuxcontainers.org/incus/docs/main/reference/instance_options/#instance-options
 	// for details.
@@ -131,21 +131,21 @@ type LXCMachineImageSource struct {
 	//
 	// For Incus:
 	//
-	//   - "ubuntu:VERSION" => "ubuntu/VERSION/cloud" from https://images.linuxcontainers.org
-	//   - "debian:VERSION" => "debian/VERSION/cloud" from https://images.linuxcontainers.org
-	//   - "images:IMAGE" => "IMAGE" from https://images.linuxcontainers.org
-	//   - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
-	//   - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+	//   - `ubuntu:VERSION` => `ubuntu/VERSION/cloud` from https://images.linuxcontainers.org
+	//   - `debian:VERSION` => `debian/VERSION/cloud` from https://images.linuxcontainers.org
+	//   - `images:IMAGE` => `IMAGE` from https://images.linuxcontainers.org
+	//   - `capi:IMAGE` => `IMAGE` from https://d14dnvi2l3tc5t.cloudfront.net
+	//   - `capi-stg:IMAGE` => `IMAGE` from https://djapqxqu5n2qu.cloudfront.net
 	//
 	// For LXD:
 	//
-	//   - "ubuntu:VERSION" => "VERSION" from https://cloud-images.ubuntu.com/releases
-	//   - "debian:VERSION" => "debian/VERSION/cloud" from https://images.lxd.canonical.com
-	//   - "images:IMAGE" => "IMAGE" from https://images.lxd.canonical.com
-	//   - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
-	//   - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+	//   - `ubuntu:VERSION` => `VERSION` from https://cloud-images.ubuntu.com/releases
+	//   - `debian:VERSION` => `debian/VERSION/cloud` from https://images.lxd.canonical.com
+	//   - `images:IMAGE` => `IMAGE` from https://images.lxd.canonical.com
+	//   - `capi:IMAGE` => `IMAGE` from https://d14dnvi2l3tc5t.cloudfront.net
+	//   - `capi-stg:IMAGE` => `IMAGE` from https://djapqxqu5n2qu.cloudfront.net
 	//
-	// Any instances of "VERSION" in the image name will be replaced with the machine version.
+	// Any instances of `VERSION` in the image name will be replaced with the machine version.
 	// For example, to use debian based kubeadm images, you can set image name to "capi:kubeadm/VERSION/debian"
 	//
 	// +optional

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclusters.yaml
@@ -308,7 +308,7 @@ spec:
                   LXCMachineTemplate objects.
 
                   For more details on the default kubeadm profile that is applied, see
-                  https://lxc.github.io/cluster-api-provider-incus/reference/profile/kubeadm.html
+                  https://capn.linuxcontainers.org/reference/profile/kubeadm.html
                 type: boolean
               unprivileged:
                 description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclusters.yaml
@@ -129,21 +129,21 @@ spec:
 
                                   For Incus:
 
-                                    - "ubuntu:VERSION" => "ubuntu/VERSION/cloud" from https://images.linuxcontainers.org
-                                    - "debian:VERSION" => "debian/VERSION/cloud" from https://images.linuxcontainers.org
-                                    - "images:IMAGE" => "IMAGE" from https://images.linuxcontainers.org
-                                    - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
-                                    - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+                                    - `ubuntu:VERSION` => `ubuntu/VERSION/cloud` from https://images.linuxcontainers.org
+                                    - `debian:VERSION` => `debian/VERSION/cloud` from https://images.linuxcontainers.org
+                                    - `images:IMAGE` => `IMAGE` from https://images.linuxcontainers.org
+                                    - `capi:IMAGE` => `IMAGE` from https://d14dnvi2l3tc5t.cloudfront.net
+                                    - `capi-stg:IMAGE` => `IMAGE` from https://djapqxqu5n2qu.cloudfront.net
 
                                   For LXD:
 
-                                    - "ubuntu:VERSION" => "VERSION" from https://cloud-images.ubuntu.com/releases
-                                    - "debian:VERSION" => "debian/VERSION/cloud" from https://images.lxd.canonical.com
-                                    - "images:IMAGE" => "IMAGE" from https://images.lxd.canonical.com
-                                    - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
-                                    - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+                                    - `ubuntu:VERSION` => `VERSION` from https://cloud-images.ubuntu.com/releases
+                                    - `debian:VERSION` => `debian/VERSION/cloud` from https://images.lxd.canonical.com
+                                    - `images:IMAGE` => `IMAGE` from https://images.lxd.canonical.com
+                                    - `capi:IMAGE` => `IMAGE` from https://d14dnvi2l3tc5t.cloudfront.net
+                                    - `capi-stg:IMAGE` => `IMAGE` from https://djapqxqu5n2qu.cloudfront.net
 
-                                  Any instances of "VERSION" in the image name will be replaced with the machine version.
+                                  Any instances of `VERSION` in the image name will be replaced with the machine version.
                                   For example, to use debian based kubeadm images, you can set image name to "capi:kubeadm/VERSION/debian"
                                 type: string
                               protocol:
@@ -187,7 +187,7 @@ spec:
 
                       The load balancer container is a single point of failure to access the workload cluster control plane. Therefore, it should only be used for development or evaluation clusters.
 
-                      Requires server extensions: "instance_oci"
+                      Requires server extensions: `instance_oci`
                     properties:
                       instanceSpec:
                         description: InstanceSpec can be used to adjust the load balancer
@@ -222,21 +222,21 @@ spec:
 
                                   For Incus:
 
-                                    - "ubuntu:VERSION" => "ubuntu/VERSION/cloud" from https://images.linuxcontainers.org
-                                    - "debian:VERSION" => "debian/VERSION/cloud" from https://images.linuxcontainers.org
-                                    - "images:IMAGE" => "IMAGE" from https://images.linuxcontainers.org
-                                    - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
-                                    - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+                                    - `ubuntu:VERSION` => `ubuntu/VERSION/cloud` from https://images.linuxcontainers.org
+                                    - `debian:VERSION` => `debian/VERSION/cloud` from https://images.linuxcontainers.org
+                                    - `images:IMAGE` => `IMAGE` from https://images.linuxcontainers.org
+                                    - `capi:IMAGE` => `IMAGE` from https://d14dnvi2l3tc5t.cloudfront.net
+                                    - `capi-stg:IMAGE` => `IMAGE` from https://djapqxqu5n2qu.cloudfront.net
 
                                   For LXD:
 
-                                    - "ubuntu:VERSION" => "VERSION" from https://cloud-images.ubuntu.com/releases
-                                    - "debian:VERSION" => "debian/VERSION/cloud" from https://images.lxd.canonical.com
-                                    - "images:IMAGE" => "IMAGE" from https://images.lxd.canonical.com
-                                    - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
-                                    - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+                                    - `ubuntu:VERSION` => `VERSION` from https://cloud-images.ubuntu.com/releases
+                                    - `debian:VERSION` => `debian/VERSION/cloud` from https://images.lxd.canonical.com
+                                    - `images:IMAGE` => `IMAGE` from https://images.lxd.canonical.com
+                                    - `capi:IMAGE` => `IMAGE` from https://d14dnvi2l3tc5t.cloudfront.net
+                                    - `capi-stg:IMAGE` => `IMAGE` from https://djapqxqu5n2qu.cloudfront.net
 
-                                  Any instances of "VERSION" in the image name will be replaced with the machine version.
+                                  Any instances of `VERSION` in the image name will be replaced with the machine version.
                                   For example, to use debian based kubeadm images, you can set image name to "capi:kubeadm/VERSION/debian"
                                 type: string
                               protocol:
@@ -280,7 +280,7 @@ spec:
 
                       When using the "ovn" mode, the load balancer address must be set in `.spec.controlPlaneEndpoint.host` on the LXCCluster object.
 
-                      Requires server extensions: "network_load_balancer", "network_load_balancer_health_checks"
+                      Requires server extensions: `network_load_balancer`, `network_load_balancer_health_checks`
                     properties:
                       networkName:
                         description: NetworkName is the name of the network to create

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclustertemplates.yaml
@@ -149,21 +149,21 @@ spec:
 
                                           For Incus:
 
-                                            - "ubuntu:VERSION" => "ubuntu/VERSION/cloud" from https://images.linuxcontainers.org
-                                            - "debian:VERSION" => "debian/VERSION/cloud" from https://images.linuxcontainers.org
-                                            - "images:IMAGE" => "IMAGE" from https://images.linuxcontainers.org
-                                            - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
-                                            - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+                                            - `ubuntu:VERSION` => `ubuntu/VERSION/cloud` from https://images.linuxcontainers.org
+                                            - `debian:VERSION` => `debian/VERSION/cloud` from https://images.linuxcontainers.org
+                                            - `images:IMAGE` => `IMAGE` from https://images.linuxcontainers.org
+                                            - `capi:IMAGE` => `IMAGE` from https://d14dnvi2l3tc5t.cloudfront.net
+                                            - `capi-stg:IMAGE` => `IMAGE` from https://djapqxqu5n2qu.cloudfront.net
 
                                           For LXD:
 
-                                            - "ubuntu:VERSION" => "VERSION" from https://cloud-images.ubuntu.com/releases
-                                            - "debian:VERSION" => "debian/VERSION/cloud" from https://images.lxd.canonical.com
-                                            - "images:IMAGE" => "IMAGE" from https://images.lxd.canonical.com
-                                            - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
-                                            - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+                                            - `ubuntu:VERSION` => `VERSION` from https://cloud-images.ubuntu.com/releases
+                                            - `debian:VERSION` => `debian/VERSION/cloud` from https://images.lxd.canonical.com
+                                            - `images:IMAGE` => `IMAGE` from https://images.lxd.canonical.com
+                                            - `capi:IMAGE` => `IMAGE` from https://d14dnvi2l3tc5t.cloudfront.net
+                                            - `capi-stg:IMAGE` => `IMAGE` from https://djapqxqu5n2qu.cloudfront.net
 
-                                          Any instances of "VERSION" in the image name will be replaced with the machine version.
+                                          Any instances of `VERSION` in the image name will be replaced with the machine version.
                                           For example, to use debian based kubeadm images, you can set image name to "capi:kubeadm/VERSION/debian"
                                         type: string
                                       protocol:
@@ -208,7 +208,7 @@ spec:
 
                               The load balancer container is a single point of failure to access the workload cluster control plane. Therefore, it should only be used for development or evaluation clusters.
 
-                              Requires server extensions: "instance_oci"
+                              Requires server extensions: `instance_oci`
                             properties:
                               instanceSpec:
                                 description: InstanceSpec can be used to adjust the
@@ -243,21 +243,21 @@ spec:
 
                                           For Incus:
 
-                                            - "ubuntu:VERSION" => "ubuntu/VERSION/cloud" from https://images.linuxcontainers.org
-                                            - "debian:VERSION" => "debian/VERSION/cloud" from https://images.linuxcontainers.org
-                                            - "images:IMAGE" => "IMAGE" from https://images.linuxcontainers.org
-                                            - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
-                                            - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+                                            - `ubuntu:VERSION` => `ubuntu/VERSION/cloud` from https://images.linuxcontainers.org
+                                            - `debian:VERSION` => `debian/VERSION/cloud` from https://images.linuxcontainers.org
+                                            - `images:IMAGE` => `IMAGE` from https://images.linuxcontainers.org
+                                            - `capi:IMAGE` => `IMAGE` from https://d14dnvi2l3tc5t.cloudfront.net
+                                            - `capi-stg:IMAGE` => `IMAGE` from https://djapqxqu5n2qu.cloudfront.net
 
                                           For LXD:
 
-                                            - "ubuntu:VERSION" => "VERSION" from https://cloud-images.ubuntu.com/releases
-                                            - "debian:VERSION" => "debian/VERSION/cloud" from https://images.lxd.canonical.com
-                                            - "images:IMAGE" => "IMAGE" from https://images.lxd.canonical.com
-                                            - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
-                                            - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+                                            - `ubuntu:VERSION` => `VERSION` from https://cloud-images.ubuntu.com/releases
+                                            - `debian:VERSION` => `debian/VERSION/cloud` from https://images.lxd.canonical.com
+                                            - `images:IMAGE` => `IMAGE` from https://images.lxd.canonical.com
+                                            - `capi:IMAGE` => `IMAGE` from https://d14dnvi2l3tc5t.cloudfront.net
+                                            - `capi-stg:IMAGE` => `IMAGE` from https://djapqxqu5n2qu.cloudfront.net
 
-                                          Any instances of "VERSION" in the image name will be replaced with the machine version.
+                                          Any instances of `VERSION` in the image name will be replaced with the machine version.
                                           For example, to use debian based kubeadm images, you can set image name to "capi:kubeadm/VERSION/debian"
                                         type: string
                                       protocol:
@@ -302,7 +302,7 @@ spec:
 
                               When using the "ovn" mode, the load balancer address must be set in `.spec.controlPlaneEndpoint.host` on the LXCCluster object.
 
-                              Requires server extensions: "network_load_balancer", "network_load_balancer_health_checks"
+                              Requires server extensions: `network_load_balancer`, `network_load_balancer_health_checks`
                             properties:
                               networkName:
                                 description: NetworkName is the name of the network

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclustertemplates.yaml
@@ -331,7 +331,7 @@ spec:
                           LXCMachineTemplate objects.
 
                           For more details on the default kubeadm profile that is applied, see
-                          https://lxc.github.io/cluster-api-provider-incus/reference/profile/kubeadm.html
+                          https://capn.linuxcontainers.org/reference/profile/kubeadm.html
                         type: boolean
                       unprivileged:
                         description: |-

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcmachines.yaml
@@ -70,11 +70,11 @@ spec:
 
                   Note that the provider will always set the following configuration keys:
 
-                  - "cloud-init.user-data": cloud-init config data
-                  - "user.cluster-name": name of owning cluster
-                  - "user.cluster-namespace": namespace of owning cluster
-                  - "user.cluster-role": instance role (e.g. control-plane, worker)
-                  - "user.machine-name": name of machine (should match instance hostname)
+                  - `cloud-init.user-data`: cloud-init config data
+                  - `user.cluster-name`: name of owning cluster
+                  - `user.cluster-namespace`: namespace of owning cluster
+                  - `user.cluster-role`: instance role (e.g. control-plane, worker)
+                  - `user.machine-name`: name of machine (should match instance hostname)
 
                   See https://linuxcontainers.org/incus/docs/main/reference/instance_options/#instance-options
                   for details.
@@ -88,9 +88,9 @@ spec:
                   For example, to specify a different network for an instance, you can use:
 
                   ```yaml
-                    # override device "eth0", to be of type "nic" and use network "my-network"
-                    devices:
-                    - eth0,type=nic,network=my-network
+                  # override device "eth0", to be of type "nic" and use network "my-network"
+                  devices:
+                  - eth0,type=nic,network=my-network
                   ```
                 items:
                   type: string
@@ -126,21 +126,21 @@ spec:
 
                       For Incus:
 
-                        - "ubuntu:VERSION" => "ubuntu/VERSION/cloud" from https://images.linuxcontainers.org
-                        - "debian:VERSION" => "debian/VERSION/cloud" from https://images.linuxcontainers.org
-                        - "images:IMAGE" => "IMAGE" from https://images.linuxcontainers.org
-                        - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
-                        - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+                        - `ubuntu:VERSION` => `ubuntu/VERSION/cloud` from https://images.linuxcontainers.org
+                        - `debian:VERSION` => `debian/VERSION/cloud` from https://images.linuxcontainers.org
+                        - `images:IMAGE` => `IMAGE` from https://images.linuxcontainers.org
+                        - `capi:IMAGE` => `IMAGE` from https://d14dnvi2l3tc5t.cloudfront.net
+                        - `capi-stg:IMAGE` => `IMAGE` from https://djapqxqu5n2qu.cloudfront.net
 
                       For LXD:
 
-                        - "ubuntu:VERSION" => "VERSION" from https://cloud-images.ubuntu.com/releases
-                        - "debian:VERSION" => "debian/VERSION/cloud" from https://images.lxd.canonical.com
-                        - "images:IMAGE" => "IMAGE" from https://images.lxd.canonical.com
-                        - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
-                        - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+                        - `ubuntu:VERSION` => `VERSION` from https://cloud-images.ubuntu.com/releases
+                        - `debian:VERSION` => `debian/VERSION/cloud` from https://images.lxd.canonical.com
+                        - `images:IMAGE` => `IMAGE` from https://images.lxd.canonical.com
+                        - `capi:IMAGE` => `IMAGE` from https://d14dnvi2l3tc5t.cloudfront.net
+                        - `capi-stg:IMAGE` => `IMAGE` from https://djapqxqu5n2qu.cloudfront.net
 
-                      Any instances of "VERSION" in the image name will be replaced with the machine version.
+                      Any instances of `VERSION` in the image name will be replaced with the machine version.
                       For example, to use debian based kubeadm images, you can set image name to "capi:kubeadm/VERSION/debian"
                     type: string
                   protocol:
@@ -153,10 +153,10 @@ spec:
                 type: object
               instanceType:
                 description: |-
-                  InstanceType is "container" or "virtual-machine". Empty defaults to "container".
+                  InstanceType is `container` or `virtual-machine`. Empty defaults to `container`.
 
-                  InstanceType may also be set to "kind", in which case OCI containers using the kindest/node
-                  images will be created. This requires server extensions: "instance_oci", "instance_oci_entrypoint".
+                  InstanceType may also be set to `kind`, in which case OCI containers using the kindest/node
+                  images will be created. This requires server extensions: `instance_oci`, `instance_oci_entrypoint`.
                 enum:
                 - container
                 - virtual-machine

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcmachinetemplates.yaml
@@ -85,11 +85,11 @@ spec:
 
                           Note that the provider will always set the following configuration keys:
 
-                          - "cloud-init.user-data": cloud-init config data
-                          - "user.cluster-name": name of owning cluster
-                          - "user.cluster-namespace": namespace of owning cluster
-                          - "user.cluster-role": instance role (e.g. control-plane, worker)
-                          - "user.machine-name": name of machine (should match instance hostname)
+                          - `cloud-init.user-data`: cloud-init config data
+                          - `user.cluster-name`: name of owning cluster
+                          - `user.cluster-namespace`: namespace of owning cluster
+                          - `user.cluster-role`: instance role (e.g. control-plane, worker)
+                          - `user.machine-name`: name of machine (should match instance hostname)
 
                           See https://linuxcontainers.org/incus/docs/main/reference/instance_options/#instance-options
                           for details.
@@ -103,9 +103,9 @@ spec:
                           For example, to specify a different network for an instance, you can use:
 
                           ```yaml
-                            # override device "eth0", to be of type "nic" and use network "my-network"
-                            devices:
-                            - eth0,type=nic,network=my-network
+                          # override device "eth0", to be of type "nic" and use network "my-network"
+                          devices:
+                          - eth0,type=nic,network=my-network
                           ```
                         items:
                           type: string
@@ -141,21 +141,21 @@ spec:
 
                               For Incus:
 
-                                - "ubuntu:VERSION" => "ubuntu/VERSION/cloud" from https://images.linuxcontainers.org
-                                - "debian:VERSION" => "debian/VERSION/cloud" from https://images.linuxcontainers.org
-                                - "images:IMAGE" => "IMAGE" from https://images.linuxcontainers.org
-                                - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
-                                - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+                                - `ubuntu:VERSION` => `ubuntu/VERSION/cloud` from https://images.linuxcontainers.org
+                                - `debian:VERSION` => `debian/VERSION/cloud` from https://images.linuxcontainers.org
+                                - `images:IMAGE` => `IMAGE` from https://images.linuxcontainers.org
+                                - `capi:IMAGE` => `IMAGE` from https://d14dnvi2l3tc5t.cloudfront.net
+                                - `capi-stg:IMAGE` => `IMAGE` from https://djapqxqu5n2qu.cloudfront.net
 
                               For LXD:
 
-                                - "ubuntu:VERSION" => "VERSION" from https://cloud-images.ubuntu.com/releases
-                                - "debian:VERSION" => "debian/VERSION/cloud" from https://images.lxd.canonical.com
-                                - "images:IMAGE" => "IMAGE" from https://images.lxd.canonical.com
-                                - "capi:IMAGE" => "IMAGE" from https://d14dnvi2l3tc5t.cloudfront.net
-                                - "capi-stg:IMAGE" => "IMAGE" from https://djapqxqu5n2qu.cloudfront.net
+                                - `ubuntu:VERSION` => `VERSION` from https://cloud-images.ubuntu.com/releases
+                                - `debian:VERSION` => `debian/VERSION/cloud` from https://images.lxd.canonical.com
+                                - `images:IMAGE` => `IMAGE` from https://images.lxd.canonical.com
+                                - `capi:IMAGE` => `IMAGE` from https://d14dnvi2l3tc5t.cloudfront.net
+                                - `capi-stg:IMAGE` => `IMAGE` from https://djapqxqu5n2qu.cloudfront.net
 
-                              Any instances of "VERSION" in the image name will be replaced with the machine version.
+                              Any instances of `VERSION` in the image name will be replaced with the machine version.
                               For example, to use debian based kubeadm images, you can set image name to "capi:kubeadm/VERSION/debian"
                             type: string
                           protocol:
@@ -168,10 +168,10 @@ spec:
                         type: object
                       instanceType:
                         description: |-
-                          InstanceType is "container" or "virtual-machine". Empty defaults to "container".
+                          InstanceType is `container` or `virtual-machine`. Empty defaults to `container`.
 
-                          InstanceType may also be set to "kind", in which case OCI containers using the kindest/node
-                          images will be created. This requires server extensions: "instance_oci", "instance_oci_entrypoint".
+                          InstanceType may also be set to `kind`, in which case OCI containers using the kindest/node
+                          images will be created. This requires server extensions: `instance_oci`, `instance_oci_entrypoint`.
                         enum:
                         - container
                         - virtual-machine

--- a/docs/book/src/reference/api/v1alpha2/api.md
+++ b/docs/book/src/reference/api/v1alpha2/api.md
@@ -110,7 +110,7 @@ bool
 profile manually and set the <code>.spec.template.spec.profiles</code> field of all
 LXCMachineTemplate objects.</p>
 <p>For more details on the default kubeadm profile that is applied, see
-<a href="https://lxc.github.io/cluster-api-provider-incus/reference/profile/kubeadm.html">https://lxc.github.io/cluster-api-provider-incus/reference/profile/kubeadm.html</a></p>
+<a href="https://capn.linuxcontainers.org/reference/profile/kubeadm.html">https://capn.linuxcontainers.org/reference/profile/kubeadm.html</a></p>
 </td>
 </tr>
 </table>
@@ -221,7 +221,7 @@ LXCLoadBalancerExternal
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCCluster">LXCCluster</a>, 
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCCluster">LXCCluster</a>,
 <a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCClusterTemplateResource">LXCClusterTemplateResource</a>)
 </p>
 <p>
@@ -301,7 +301,7 @@ bool
 profile manually and set the <code>.spec.template.spec.profiles</code> field of all
 LXCMachineTemplate objects.</p>
 <p>For more details on the default kubeadm profile that is applied, see
-<a href="https://lxc.github.io/cluster-api-provider-incus/reference/profile/kubeadm.html">https://lxc.github.io/cluster-api-provider-incus/reference/profile/kubeadm.html</a></p>
+<a href="https://capn.linuxcontainers.org/reference/profile/kubeadm.html">https://capn.linuxcontainers.org/reference/profile/kubeadm.html</a></p>
 </td>
 </tr>
 </tbody>
@@ -535,7 +535,7 @@ bool
 profile manually and set the <code>.spec.template.spec.profiles</code> field of all
 LXCMachineTemplate objects.</p>
 <p>For more details on the default kubeadm profile that is applied, see
-<a href="https://lxc.github.io/cluster-api-provider-incus/reference/profile/kubeadm.html">https://lxc.github.io/cluster-api-provider-incus/reference/profile/kubeadm.html</a></p>
+<a href="https://capn.linuxcontainers.org/reference/profile/kubeadm.html">https://capn.linuxcontainers.org/reference/profile/kubeadm.html</a></p>
 </td>
 </tr>
 </table>
@@ -962,7 +962,7 @@ LXCMachineStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCLoadBalancerMachineSpec">LXCLoadBalancerMachineSpec</a>, 
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCLoadBalancerMachineSpec">LXCLoadBalancerMachineSpec</a>,
 <a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCMachineSpec">LXCMachineSpec</a>)
 </p>
 <p>
@@ -1049,7 +1049,7 @@ string
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCMachine">LXCMachine</a>, 
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCMachine">LXCMachine</a>,
 <a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCMachineTemplateResource">LXCMachineTemplateResource</a>)
 </p>
 <p>

--- a/docs/book/src/reference/api/v1alpha2/api.md
+++ b/docs/book/src/reference/api/v1alpha2/api.md
@@ -179,7 +179,7 @@ LXCLoadBalancerInstance
 <p>The controller will automatically update the list of backends on the haproxy configuration as control plane nodes are added or removed from the cluster.</p>
 <p>No other configuration is required for &ldquo;oci&rdquo; mode. The load balancer instance can be configured through the .instanceSpec field.</p>
 <p>The load balancer container is a single point of failure to access the workload cluster control plane. Therefore, it should only be used for development or evaluation clusters.</p>
-<p>Requires server extensions: &ldquo;instance_oci&rdquo;</p>
+<p>Requires server extensions: <code>instance_oci</code></p>
 </td>
 </tr>
 <tr>
@@ -197,7 +197,7 @@ LXCLoadBalancerOVN
 <p>The controller will automatically update the list of backends for the network load balancer as control plane nodes are added or removed from the cluster.</p>
 <p>The cluster administrator is responsible to ensure that the OVN network is configured properly and that the LXCMachineTemplate objects have appropriate profiles to use the OVN network.</p>
 <p>When using the &ldquo;ovn&rdquo; mode, the load balancer address must be set in <code>.spec.controlPlaneEndpoint.host</code> on the LXCCluster object.</p>
-<p>Requires server extensions: &ldquo;network_load_balancer&rdquo;, &ldquo;network_load_balancer_health_checks&rdquo;</p>
+<p>Requires server extensions: <code>network_load_balancer</code>, <code>network_load_balancer_health_checks</code></p>
 </td>
 </tr>
 <tr>
@@ -221,7 +221,7 @@ LXCLoadBalancerExternal
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCCluster">LXCCluster</a>,
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCCluster">LXCCluster</a>, 
 <a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCClusterTemplateResource">LXCClusterTemplateResource</a>)
 </p>
 <p>
@@ -714,6 +714,27 @@ a default image based on the load balancer type will be used.</p>
 </ul>
 </td>
 </tr>
+<tr>
+<td>
+<code>target</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Target where the load balancer machine should be provisioned, when
+infrastructure is a production cluster.</p>
+<p>Can be one of:</p>
+<ul>
+<li><code>name</code>: where <code>name</code> is the name of a cluster member.</li>
+<li><code>@name</code>: where <code>name</code> is the name of a cluster group.</li>
+</ul>
+<p>Target is ignored when infrastructure is single-node (e.g. for
+development purposes).</p>
+<p>For more information on cluster groups, you can refer to <a href="https://linuxcontainers.org/incus/docs/main/explanation/clustering/#cluster-groups">https://linuxcontainers.org/incus/docs/main/explanation/clustering/#cluster-groups</a></p>
+</td>
+</tr>
 </tbody>
 </table>
 <h3 id="infrastructure.cluster.x-k8s.io/v1alpha2.LXCLoadBalancerOVN">LXCLoadBalancerOVN
@@ -806,7 +827,9 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>InstanceType is &ldquo;container&rdquo; or &ldquo;virtual-machine&rdquo;. Empty defaults to &ldquo;container&rdquo;.</p>
+<p>InstanceType is <code>container</code> or <code>virtual-machine</code>. Empty defaults to <code>container</code>.</p>
+<p>InstanceType may also be set to <code>kind</code>, in which case OCI containers using the kindest/node
+images will be created. This requires server extensions: <code>instance_oci</code>, <code>instance_oci_entrypoint</code>.</p>
 </td>
 </tr>
 <tr>
@@ -850,7 +873,7 @@ string
 <p>Devices allows overriding the configuration of the instance disk or network.</p>
 <p>Device configuration must be formatted using the syntax &ldquo;<device>,<key>=<value>&rdquo;.</p>
 <p>For example, to specify a different network for an instance, you can use:</p>
-<pre><code class="language-yaml">  # override device &quot;eth0&quot;, to be of type &quot;nic&quot; and use network &quot;my-network&quot;
+<pre><code class="language-yaml"># override device &quot;eth0&quot;, to be of type &quot;nic&quot; and use network &quot;my-network&quot;
 devices:
 - eth0,type=nic,network=my-network
 </code></pre>
@@ -868,11 +891,11 @@ map[string]string
 <p>Config allows overriding instance configuration keys.</p>
 <p>Note that the provider will always set the following configuration keys:</p>
 <ul>
-<li>&ldquo;cloud-init.user-data&rdquo;: cloud-init config data</li>
-<li>&ldquo;user.cluster-name&rdquo;: name of owning cluster</li>
-<li>&ldquo;user.cluster-namespace&rdquo;: namespace of owning cluster</li>
-<li>&ldquo;user.cluster-role&rdquo;: instance role (e.g. control-plane, worker)</li>
-<li>&ldquo;user.machine-name&rdquo;: name of machine (should match instance hostname)</li>
+<li><code>cloud-init.user-data</code>: cloud-init config data</li>
+<li><code>user.cluster-name</code>: name of owning cluster</li>
+<li><code>user.cluster-namespace</code>: namespace of owning cluster</li>
+<li><code>user.cluster-role</code>: instance role (e.g. control-plane, worker)</li>
+<li><code>user.machine-name</code>: name of machine (should match instance hostname)</li>
 </ul>
 <p>See <a href="https://linuxcontainers.org/incus/docs/main/reference/instance_options/#instance-options">https://linuxcontainers.org/incus/docs/main/reference/instance_options/#instance-options</a>
 for details.</p>
@@ -897,6 +920,27 @@ versions, refer to the documentation for more details on which versions
 are supported and how to build a base image for any version.</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>target</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Target where the machine should be provisioned, when infrastructure
+is a production cluster.</p>
+<p>Can be one of:</p>
+<ul>
+<li><code>name</code>: where <code>name</code> is the name of a cluster member.</li>
+<li><code>@name</code>: where <code>name</code> is the name of a cluster group.</li>
+</ul>
+<p>Target is ignored when infrastructure is single-node (e.g. for
+development purposes).</p>
+<p>For more information on cluster groups, you can refer to <a href="https://linuxcontainers.org/incus/docs/main/explanation/clustering/#cluster-groups">https://linuxcontainers.org/incus/docs/main/explanation/clustering/#cluster-groups</a></p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -918,7 +962,7 @@ LXCMachineStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCLoadBalancerMachineSpec">LXCLoadBalancerMachineSpec</a>,
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCLoadBalancerMachineSpec">LXCLoadBalancerMachineSpec</a>, 
 <a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCMachineSpec">LXCMachineSpec</a>)
 </p>
 <p>
@@ -941,13 +985,26 @@ string
 <td>
 <em>(Optional)</em>
 <p>Name is the image name or alias.</p>
-<p>Note that Incus and Canonical LXD use incompatible image servers
-for Ubuntu images. To address this issue, setting image name to
-<code>ubuntu:VERSION</code> is a shortcut for:</p>
+<p>Note that Incus and Canonical LXD use incompatible image servers. To help
+mitigate this issue, the following image names are recognized:</p>
+<p>For Incus:</p>
 <ul>
-<li>Incus: &ldquo;images:ubuntu/VERSION/cloud&rdquo; (from <a href="https://images.linuxcontainers.org">https://images.linuxcontainers.org</a>)</li>
-<li>LXD: &ldquo;ubuntu:VERSION&rdquo; (from <a href="https://cloud-images.ubuntu.com/releases">https://cloud-images.ubuntu.com/releases</a>)</li>
+<li><code>ubuntu:VERSION</code> =&gt; <code>ubuntu/VERSION/cloud</code> from <a href="https://images.linuxcontainers.org">https://images.linuxcontainers.org</a></li>
+<li><code>debian:VERSION</code> =&gt; <code>debian/VERSION/cloud</code> from <a href="https://images.linuxcontainers.org">https://images.linuxcontainers.org</a></li>
+<li><code>images:IMAGE</code> =&gt; <code>IMAGE</code> from <a href="https://images.linuxcontainers.org">https://images.linuxcontainers.org</a></li>
+<li><code>capi:IMAGE</code> =&gt; <code>IMAGE</code> from <a href="https://d14dnvi2l3tc5t.cloudfront.net">https://d14dnvi2l3tc5t.cloudfront.net</a></li>
+<li><code>capi-stg:IMAGE</code> =&gt; <code>IMAGE</code> from <a href="https://djapqxqu5n2qu.cloudfront.net">https://djapqxqu5n2qu.cloudfront.net</a></li>
 </ul>
+<p>For LXD:</p>
+<ul>
+<li><code>ubuntu:VERSION</code> =&gt; <code>VERSION</code> from <a href="https://cloud-images.ubuntu.com/releases">https://cloud-images.ubuntu.com/releases</a></li>
+<li><code>debian:VERSION</code> =&gt; <code>debian/VERSION/cloud</code> from <a href="https://images.lxd.canonical.com">https://images.lxd.canonical.com</a></li>
+<li><code>images:IMAGE</code> =&gt; <code>IMAGE</code> from <a href="https://images.lxd.canonical.com">https://images.lxd.canonical.com</a></li>
+<li><code>capi:IMAGE</code> =&gt; <code>IMAGE</code> from <a href="https://d14dnvi2l3tc5t.cloudfront.net">https://d14dnvi2l3tc5t.cloudfront.net</a></li>
+<li><code>capi-stg:IMAGE</code> =&gt; <code>IMAGE</code> from <a href="https://djapqxqu5n2qu.cloudfront.net">https://djapqxqu5n2qu.cloudfront.net</a></li>
+</ul>
+<p>Any instances of <code>VERSION</code> in the image name will be replaced with the machine version.
+For example, to use debian based kubeadm images, you can set image name to &ldquo;capi:kubeadm/VERSION/debian&rdquo;</p>
 </td>
 </tr>
 <tr>
@@ -992,7 +1049,7 @@ string
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCMachine">LXCMachine</a>,
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCMachine">LXCMachine</a>, 
 <a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCMachineTemplateResource">LXCMachineTemplateResource</a>)
 </p>
 <p>
@@ -1027,7 +1084,9 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>InstanceType is &ldquo;container&rdquo; or &ldquo;virtual-machine&rdquo;. Empty defaults to &ldquo;container&rdquo;.</p>
+<p>InstanceType is <code>container</code> or <code>virtual-machine</code>. Empty defaults to <code>container</code>.</p>
+<p>InstanceType may also be set to <code>kind</code>, in which case OCI containers using the kindest/node
+images will be created. This requires server extensions: <code>instance_oci</code>, <code>instance_oci_entrypoint</code>.</p>
 </td>
 </tr>
 <tr>
@@ -1071,7 +1130,7 @@ string
 <p>Devices allows overriding the configuration of the instance disk or network.</p>
 <p>Device configuration must be formatted using the syntax &ldquo;<device>,<key>=<value>&rdquo;.</p>
 <p>For example, to specify a different network for an instance, you can use:</p>
-<pre><code class="language-yaml">  # override device &quot;eth0&quot;, to be of type &quot;nic&quot; and use network &quot;my-network&quot;
+<pre><code class="language-yaml"># override device &quot;eth0&quot;, to be of type &quot;nic&quot; and use network &quot;my-network&quot;
 devices:
 - eth0,type=nic,network=my-network
 </code></pre>
@@ -1089,11 +1148,11 @@ map[string]string
 <p>Config allows overriding instance configuration keys.</p>
 <p>Note that the provider will always set the following configuration keys:</p>
 <ul>
-<li>&ldquo;cloud-init.user-data&rdquo;: cloud-init config data</li>
-<li>&ldquo;user.cluster-name&rdquo;: name of owning cluster</li>
-<li>&ldquo;user.cluster-namespace&rdquo;: namespace of owning cluster</li>
-<li>&ldquo;user.cluster-role&rdquo;: instance role (e.g. control-plane, worker)</li>
-<li>&ldquo;user.machine-name&rdquo;: name of machine (should match instance hostname)</li>
+<li><code>cloud-init.user-data</code>: cloud-init config data</li>
+<li><code>user.cluster-name</code>: name of owning cluster</li>
+<li><code>user.cluster-namespace</code>: namespace of owning cluster</li>
+<li><code>user.cluster-role</code>: instance role (e.g. control-plane, worker)</li>
+<li><code>user.machine-name</code>: name of machine (should match instance hostname)</li>
 </ul>
 <p>See <a href="https://linuxcontainers.org/incus/docs/main/reference/instance_options/#instance-options">https://linuxcontainers.org/incus/docs/main/reference/instance_options/#instance-options</a>
 for details.</p>
@@ -1116,6 +1175,27 @@ the version of the machine.</p>
 <p>Note that the default source does not support images for all Kubernetes
 versions, refer to the documentation for more details on which versions
 are supported and how to build a base image for any version.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>target</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Target where the machine should be provisioned, when infrastructure
+is a production cluster.</p>
+<p>Can be one of:</p>
+<ul>
+<li><code>name</code>: where <code>name</code> is the name of a cluster member.</li>
+<li><code>@name</code>: where <code>name</code> is the name of a cluster group.</li>
+</ul>
+<p>Target is ignored when infrastructure is single-node (e.g. for
+development purposes).</p>
+<p>For more information on cluster groups, you can refer to <a href="https://linuxcontainers.org/incus/docs/main/explanation/clustering/#cluster-groups">https://linuxcontainers.org/incus/docs/main/explanation/clustering/#cluster-groups</a></p>
 </td>
 </tr>
 </tbody>
@@ -1331,7 +1411,9 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>InstanceType is &ldquo;container&rdquo; or &ldquo;virtual-machine&rdquo;. Empty defaults to &ldquo;container&rdquo;.</p>
+<p>InstanceType is <code>container</code> or <code>virtual-machine</code>. Empty defaults to <code>container</code>.</p>
+<p>InstanceType may also be set to <code>kind</code>, in which case OCI containers using the kindest/node
+images will be created. This requires server extensions: <code>instance_oci</code>, <code>instance_oci_entrypoint</code>.</p>
 </td>
 </tr>
 <tr>
@@ -1375,7 +1457,7 @@ string
 <p>Devices allows overriding the configuration of the instance disk or network.</p>
 <p>Device configuration must be formatted using the syntax &ldquo;<device>,<key>=<value>&rdquo;.</p>
 <p>For example, to specify a different network for an instance, you can use:</p>
-<pre><code class="language-yaml">  # override device &quot;eth0&quot;, to be of type &quot;nic&quot; and use network &quot;my-network&quot;
+<pre><code class="language-yaml"># override device &quot;eth0&quot;, to be of type &quot;nic&quot; and use network &quot;my-network&quot;
 devices:
 - eth0,type=nic,network=my-network
 </code></pre>
@@ -1393,11 +1475,11 @@ map[string]string
 <p>Config allows overriding instance configuration keys.</p>
 <p>Note that the provider will always set the following configuration keys:</p>
 <ul>
-<li>&ldquo;cloud-init.user-data&rdquo;: cloud-init config data</li>
-<li>&ldquo;user.cluster-name&rdquo;: name of owning cluster</li>
-<li>&ldquo;user.cluster-namespace&rdquo;: namespace of owning cluster</li>
-<li>&ldquo;user.cluster-role&rdquo;: instance role (e.g. control-plane, worker)</li>
-<li>&ldquo;user.machine-name&rdquo;: name of machine (should match instance hostname)</li>
+<li><code>cloud-init.user-data</code>: cloud-init config data</li>
+<li><code>user.cluster-name</code>: name of owning cluster</li>
+<li><code>user.cluster-namespace</code>: namespace of owning cluster</li>
+<li><code>user.cluster-role</code>: instance role (e.g. control-plane, worker)</li>
+<li><code>user.machine-name</code>: name of machine (should match instance hostname)</li>
 </ul>
 <p>See <a href="https://linuxcontainers.org/incus/docs/main/reference/instance_options/#instance-options">https://linuxcontainers.org/incus/docs/main/reference/instance_options/#instance-options</a>
 for details.</p>
@@ -1420,6 +1502,27 @@ the version of the machine.</p>
 <p>Note that the default source does not support images for all Kubernetes
 versions, refer to the documentation for more details on which versions
 are supported and how to build a base image for any version.</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>target</code><br/>
+<em>
+string
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Target where the machine should be provisioned, when infrastructure
+is a production cluster.</p>
+<p>Can be one of:</p>
+<ul>
+<li><code>name</code>: where <code>name</code> is the name of a cluster member.</li>
+<li><code>@name</code>: where <code>name</code> is the name of a cluster group.</li>
+</ul>
+<p>Target is ignored when infrastructure is single-node (e.g. for
+development purposes).</p>
+<p>For more information on cluster groups, you can refer to <a href="https://linuxcontainers.org/incus/docs/main/explanation/clustering/#cluster-groups">https://linuxcontainers.org/incus/docs/main/explanation/clustering/#cluster-groups</a></p>
 </td>
 </tr>
 </table>

--- a/docs/book/src/reference/profile/kubeadm.md
+++ b/docs/book/src/reference/profile/kubeadm.md
@@ -6,7 +6,7 @@ In order for Kubernetes to work properly on LXC, the following profile is applie
 
 ```yaml
 # incus profile create kubeadm
-# curl https://lxc.github.io/cluster-api-provider-incus/static/v0.1/profile.yaml | incus profile edit kubeadm
+# curl https://capn.linuxcontainers.org/static/v0.1/profile.yaml | incus profile edit kubeadm
 
 {{#include ../../static/v0.1/profile.yaml }}
 ```
@@ -17,7 +17,7 @@ When using unprivileged containers, the following profile is applied instead:
 
 ```yaml
 # incus profile create kubeadm-unprivileged
-# curl https://lxc.github.io/cluster-api-provider-incus/static/v0.1/unprivileged.yaml | incus profile edit kubeadm-unprivileged
+# curl https://capn.linuxcontainers.org/static/v0.1/unprivileged.yaml | incus profile edit kubeadm-unprivileged
 
 {{#include ../../static/v0.1/unprivileged.yaml }}
 ```
@@ -28,7 +28,7 @@ When using unprivileged containers with Canonical LXD, it is also required to en
 
 ```yaml
 # lxc profile create kubeadm-unprivileged
-# curl https://lxc.github.io/cluster-api-provider-incus/static/v0.1/unprivileged-lxd.yaml | lxc profile edit kubeadm-unprivileged
+# curl https://capn.linuxcontainers.org/static/v0.1/unprivileged-lxd.yaml | lxc profile edit kubeadm-unprivileged
 
 {{#include ../../static/v0.1/unprivileged-lxd.yaml }}
 ```
@@ -39,7 +39,7 @@ When using privileged kind containers, the following profile is applied:
 
 ```yaml
 # incus profile create kind
-# curl https://lxc.github.io/cluster-api-provider-incus/static/v0.1/kind.yaml | lxc profile edit kind
+# curl https://capn.linuxcontainers.org/static/v0.1/kind.yaml | lxc profile edit kind
 
 {{#include ../../static/v0.1/kind.yaml }}
 ```
@@ -50,7 +50,7 @@ When using unprivileged kind containers, the following profile is applied:
 
 ```yaml
 # incus profile create kind-unprivileged
-# curl https://lxc.github.io/cluster-api-provider-incus/static/v0.1/kind-unprivileged.yaml | lxc profile edit kind-unprivileged
+# curl https://capn.linuxcontainers.org/static/v0.1/kind-unprivileged.yaml | lxc profile edit kind-unprivileged
 
 {{#include ../../static/v0.1/kind.yaml }}
 ```

--- a/docs/book/src/tutorial/quick-start.md
+++ b/docs/book/src/tutorial/quick-start.md
@@ -171,7 +171,7 @@ This can be done with the following commands:
 mkdir -p ~/.cluster-api
 
 curl -o ~/.cluster-api/clusterctl.yaml \
-  https://lxc.github.io/cluster-api-provider-incus/static/v0.1/clusterctl.yaml
+  https://capn.linuxcontainers.org/static/v0.1/clusterctl.yaml
 ```
 
 Then, initialize `incus` infrastructure provider:


### PR DESCRIPTION
### Summary

Use consistent style in API documentation and regenerate API docs. Also update all references from https://lxc.github.io/cluster-api-provider-incus/ to https://capn.linuxcontainers.org

