### PR TITLE
support debian trixie in e2e tests and image builder

### DIFF
--- a/cmd/exp/image-builder/base_images.go
+++ b/cmd/exp/image-builder/base_images.go
@@ -27,4 +27,9 @@ var wellKnownBaseImages = map[string]baseImageInfo{
 		releaseName: "bookworm",
 		variantName: "debian",
 	},
+	"debian:13": {
+		fullName:    "debian trixie",
+		releaseName: "trixie",
+		variantName: "debian",
+	},
 }

--- a/cmd/exp/image-builder/cmd_root.go
+++ b/cmd/exp/image-builder/cmd_root.go
@@ -57,12 +57,12 @@ var (
 
 			switch cfg.baseImage {
 			case "debian":
-				cfg.baseImage = "debian:12"
+				cfg.baseImage = "debian:13"
 			case "ubuntu":
 				cfg.baseImage = "ubuntu:24.04"
-			case "debian:12", "ubuntu:22.04", "ubuntu:24.04":
+			case "debian:12", "debian:13", "ubuntu:22.04", "ubuntu:24.04":
 			default:
-				return fmt.Errorf("invalid value for --base-image argument %q, must be one of [ubuntu:22.04, ubuntu:24.04, debian:12]", cfg.baseImage)
+				return fmt.Errorf("invalid value for --base-image argument %q, must be one of [ubuntu:22.04, ubuntu:24.04, debian:12, debian:13]", cfg.baseImage)
 			}
 
 			opts, err := lxc.ConfigurationFromLocal(cfg.configFile, cfg.configRemoteName, false)

--- a/templates/cluster-template.rc
+++ b/templates/cluster-template.rc
@@ -21,7 +21,7 @@ export WORKER_MACHINE_COUNT=1
 ## [optional] Base image to use. This must be set if there are no base images for the target Kubernetes version.
 ##
 ## See [1] for a list of pre-built kubeadm images that are available.
-## See [2] for a list of well-known image prefixes that are supported, e.g. "ubuntu:24.04" or "debian:12"
+## See [2] for a list of well-known image prefixes that are supported, e.g. "ubuntu:24.04" or "debian:13"
 ##
 ## Set INSTALL_KUBEADM=true to inject preKubeadmCommands to install kubeadm for the target Kubernetes version.
 ##

--- a/test/e2e/suites/e2e/quick_start_debian_test.go
+++ b/test/e2e/suites/e2e/quick_start_debian_test.go
@@ -20,7 +20,7 @@ var _ = Describe("QuickStart", func() {
 		BeforeEach(func(ctx context.Context) {
 			e2eCtx.OverrideVariables(map[string]string{
 				"KUBERNETES_VERSION": "v1.33.3", // Kubernetes version without pre-built images
-				"LXC_IMAGE_NAME":     "debian:12",
+				"LXC_IMAGE_NAME":     "debian:13",
 				"INSTALL_KUBEADM":    "true",
 			})
 		})


### PR DESCRIPTION
### Summary

Adjust image builder to use debian trixie by default, use Debian Trixie in e2e tests