### PR TITLE
chore: use LaunchOptions for all instance configs

### DIFF
--- a/cmd/exp/image-builder/run_stage_create_instance.go
+++ b/cmd/exp/image-builder/run_stage_create_instance.go
@@ -7,6 +7,7 @@ import (
 	"github.com/lxc/incus/v6/shared/api"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
+	"github.com/lxc/cluster-api-provider-incus/internal/instances"
 	"github.com/lxc/cluster-api-provider-incus/internal/lxc"
 )
 
@@ -22,23 +23,9 @@ func (*stageCreateInstance) run(ctx context.Context) error {
 		return fmt.Errorf("failed to pick image source for base image %q: %w", cfg.baseImage, err)
 	}
 
-	// LXD needs security.nesting=true for containerd to work properly (we need to pull images)
-	var config map[string]string
-	if cfg.instanceType == lxc.Container {
-		config = map[string]string{
-			"security.nesting": "true",
-		}
-	}
-
-	instance := api.InstancesPost{
-		Name:   cfg.instanceName,
-		Source: image,
-		Type:   api.InstanceType(cfg.instanceType),
-		InstancePut: api.InstancePut{
-			Config:   config,
-			Profiles: cfg.instanceProfiles,
-		},
-	}
+	launchOpts := instances.DefaultKubeadmLaunchOptions(api.InstanceType(cfg.instanceType), false, lxcClient.GetServerName(), false).
+		WithImage(image).
+		WithProfiles(cfg.instanceProfiles)
 
 	// set size of root volume to 5GB for virtual machines
 	if cfg.instanceType == lxc.VirtualMachine {
@@ -49,20 +36,20 @@ func (*stageCreateInstance) run(ctx context.Context) error {
 
 		for _, pool := range pools {
 			if pool.Status == api.StoragePoolStatusCreated {
-				instance.Devices = map[string]map[string]string{
+				launchOpts = launchOpts.WithDevices(map[string]map[string]string{
 					"root": {
 						"type": "disk",
 						"pool": pool.Name,
 						"path": "/",
 						"size": "5GiB",
 					},
-				}
+				})
 			}
 		}
 	}
 
 	log.FromContext(ctx).V(1).Info("Launching instance")
-	if _, err := lxcClient.WaitForLaunchInstance(ctx, instance, &lxc.LaunchOptions{}); err != nil {
+	if _, err := lxcClient.WaitForLaunchInstance(ctx, cfg.instanceName, launchOpts); err != nil {
 		return fmt.Errorf("failed to launch builder instance: %w", err)
 	}
 

--- a/cmd/exp/image-builder/run_stage_validate_image.go
+++ b/cmd/exp/image-builder/run_stage_validate_image.go
@@ -27,18 +27,13 @@ func (*stageValidateKubeadmImage) run(ctx context.Context) error {
 
 	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("instance.name", instanceName))
 
+	launchOpts := (&lxc.LaunchOptions{}).
+		WithImage(api.InstanceSource{Type: "image", Alias: cfg.imageAlias}).
+		WithInstanceType(api.InstanceType(cfg.instanceType)).
+		WithProfiles(cfg.instanceProfiles)
+
 	log.FromContext(ctx).V(1).Info("Launching test instance")
-	if _, err := lxcClient.WaitForLaunchInstance(ctx, api.InstancesPost{
-		Name: instanceName,
-		Type: api.InstanceType(cfg.instanceType),
-		Source: api.InstanceSource{
-			Type:  "image",
-			Alias: cfg.imageAlias,
-		},
-		InstancePut: api.InstancePut{
-			Profiles: cfg.instanceProfiles,
-		},
-	}, &lxc.LaunchOptions{}); err != nil {
+	if _, err := lxcClient.WaitForLaunchInstance(ctx, instanceName, launchOpts); err != nil {
 		return fmt.Errorf("failed to launch validation instance: %w", err)
 	}
 

--- a/internal/instances/haproxy.go
+++ b/internal/instances/haproxy.go
@@ -1,8 +1,9 @@
 package instances
 
 import (
-	"github.com/lxc/cluster-api-provider-incus/internal/lxc"
 	"github.com/lxc/incus/v6/shared/api"
+
+	"github.com/lxc/cluster-api-provider-incus/internal/lxc"
 )
 
 // DefaultHaproxyLXCLaunchOptions is default options for LXC haproxy load balancer containers

--- a/internal/instances/haproxy.go
+++ b/internal/instances/haproxy.go
@@ -1,0 +1,38 @@
+package instances
+
+import (
+	"github.com/lxc/cluster-api-provider-incus/internal/lxc"
+	"github.com/lxc/incus/v6/shared/api"
+)
+
+// DefaultHaproxyLXCLaunchOptions is default options for LXC haproxy load balancer containers
+func DefaultHaproxyLXCLaunchOptions() *lxc.LaunchOptions {
+	return (&lxc.LaunchOptions{}).
+		WithInstanceType(api.InstanceTypeContainer).
+		WithImage(defaultHaproxyLXCImage)
+}
+
+// DefaultHaproxyOCILaunchOptions is default options for OCI haproxy load balancer containers
+func DefaultHaproxyOCILaunchOptions() *lxc.LaunchOptions {
+	return (&lxc.LaunchOptions{}).
+		WithInstanceType(api.InstanceTypeContainer).
+		WithImage(defaultHaproxyOCIImage)
+}
+
+var (
+	// defaultHaproxyLXCImage is the default image for LXC haproxy containers
+	defaultHaproxyLXCImage = api.InstanceSource{
+		Type:     "image",
+		Protocol: "simplestreams",
+		Server:   lxc.DefaultSimplestreamsServer,
+		Alias:    "haproxy",
+	}
+
+	// defaultHaproxyOCIImage is the default image for OCI haproxy containers
+	defaultHaproxyOCIImage = api.InstanceSource{
+		Type:     "image",
+		Protocol: "oci",
+		Server:   "https://ghcr.io",
+		Alias:    "lxc/cluster-api-provider-incus/haproxy:v20230606-42a2262b",
+	}
+)

--- a/internal/instances/kind.go
+++ b/internal/instances/kind.go
@@ -3,9 +3,10 @@ package instances
 import (
 	"strings"
 
+	"github.com/lxc/incus/v6/shared/api"
+
 	"github.com/lxc/cluster-api-provider-incus/internal/lxc"
 	"github.com/lxc/cluster-api-provider-incus/internal/static"
-	"github.com/lxc/incus/v6/shared/api"
 )
 
 // DefaultKindLaunchOptions is default seed files and mutations required for kindest/node images.

--- a/internal/instances/kind.go
+++ b/internal/instances/kind.go
@@ -5,14 +5,26 @@ import (
 
 	"github.com/lxc/cluster-api-provider-incus/internal/lxc"
 	"github.com/lxc/cluster-api-provider-incus/internal/static"
+	"github.com/lxc/incus/v6/shared/api"
 )
 
 // DefaultKindLaunchOptions is default seed files and mutations required for kindest/node images.
-func DefaultKindLaunchOptions() *lxc.LaunchOptions {
-	return (&lxc.LaunchOptions{}).
+func DefaultKindLaunchOptions(privileged bool, skipProfile bool) *lxc.LaunchOptions {
+	opts := (&lxc.LaunchOptions{}).
+		WithInstanceType(api.InstanceTypeContainer).
 		WithSeedFiles(defaultKindSeedFiles).
 		WithReplacements(defaultKindReplacements).
 		WithSymlinks(defaultKindSymlinks)
+
+	// apply profile for Kubernetes to run in LXC containers
+	if !skipProfile {
+		profile := static.DefaultKindProfile(privileged)
+		opts = opts.
+			WithConfig(profile.Config).
+			WithDevices(profile.Devices)
+	}
+
+	return opts
 }
 
 // defaultKindSeedFiles that are injected to LXCMachine kind instances.

--- a/internal/instances/kubeadm.go
+++ b/internal/instances/kubeadm.go
@@ -1,14 +1,28 @@
 package instances
 
 import (
+	"github.com/lxc/incus/v6/shared/api"
+
 	"github.com/lxc/cluster-api-provider-incus/internal/lxc"
 	"github.com/lxc/cluster-api-provider-incus/internal/static"
 )
 
 // DefaultKubeadmLaunchOptions is default seed files for kubeadm images.
-func DefaultKubeadmLaunchOptions() *lxc.LaunchOptions {
-	return (&lxc.LaunchOptions{}).
+func DefaultKubeadmLaunchOptions(instanceType api.InstanceType, privileged bool, serverName string, skipProfile bool) *lxc.LaunchOptions {
+	opts := (&lxc.LaunchOptions{}).
+		WithInstanceType(instanceType).
 		WithSeedFiles(defaultKubeadmSeedFiles)
+
+	// apply profile for Kubernetes to run in LXC containers
+	if instanceType == api.InstanceTypeContainer && !skipProfile {
+		profile := static.DefaultKubeadmProfile(privileged, serverName)
+		opts = opts.
+			WithConfig(profile.Config).
+			WithDevices(profile.Devices)
+	}
+
+	return opts
+
 }
 
 // defaultKubeadmSeedFiles that are injected to LXCMachine instances.

--- a/internal/lxc/client_instances_launch_options.go
+++ b/internal/lxc/client_instances_launch_options.go
@@ -3,6 +3,8 @@ package lxc
 import (
 	"maps"
 	"strings"
+
+	"github.com/lxc/incus/v6/shared/api"
 )
 
 // LaunchOptions describe additional provisioning actions for machines.
@@ -17,6 +19,18 @@ type LaunchOptions struct {
 	// The replacer is expected to be idempotent.
 	// Not supported by virtual-machine instance types.
 	replacements map[string]*strings.Replacer
+	// devices is instance device configuration.
+	devices map[string]map[string]string
+	// config is instance configuration.
+	config map[string]string
+	// profiles is instance profiles.
+	profiles []string
+	// image is the instance source.
+	image api.InstanceSource
+	// flavor is the instance flavor.
+	flavor string
+	// instanceType is the instance type.
+	instanceType api.InstanceType
 }
 
 // WithSeedFiles mutates the object with extra seed files. The object is returned to simplify chaining operations.
@@ -46,5 +60,49 @@ func (o *LaunchOptions) WithSymlinks(new map[string]string) *LaunchOptions {
 	} else {
 		maps.Copy(o.symlinks, new)
 	}
+	return o
+}
+
+// WithDevices adds instance devices.
+func (o *LaunchOptions) WithDevices(new map[string]map[string]string) *LaunchOptions {
+	if o.devices == nil {
+		o.devices = maps.Clone(new)
+	} else {
+		maps.Copy(o.devices, new)
+	}
+	return o
+}
+
+// WithConfig adds instance config.
+func (o *LaunchOptions) WithConfig(new map[string]string) *LaunchOptions {
+	if o.config == nil {
+		o.config = maps.Clone(new)
+	} else {
+		maps.Copy(o.config, new)
+	}
+	return o
+}
+
+// WithProfiles adds instance profiles.
+func (o *LaunchOptions) WithProfiles(new []string) *LaunchOptions {
+	o.profiles = append(o.profiles, new...)
+	return o
+}
+
+// WithImage sets the instance image.
+func (o *LaunchOptions) WithImage(image api.InstanceSource) *LaunchOptions {
+	o.image = image
+	return o
+}
+
+// WithFlavor sets the instance flavor.
+func (o *LaunchOptions) WithFlavor(v string) *LaunchOptions {
+	o.flavor = v
+	return o
+}
+
+// WithInstanceType sets the instance type (container or virtual-machine)
+func (o *LaunchOptions) WithInstanceType(v api.InstanceType) *LaunchOptions {
+	o.instanceType = v
 	return o
 }


### PR DESCRIPTION
### Summary

Followup on #129, improve the LaunchOptions API and make instance configuration easier to consume