### PR TITLE
Run haproxy as PID 1 in OCI containers

### DIFF
--- a/internal/instances/haproxy.go
+++ b/internal/instances/haproxy.go
@@ -17,7 +17,9 @@ func DefaultHaproxyLXCLaunchOptions() *lxc.LaunchOptions {
 func DefaultHaproxyOCILaunchOptions() *lxc.LaunchOptions {
 	return (&lxc.LaunchOptions{}).
 		WithInstanceType(api.InstanceTypeContainer).
-		WithImage(defaultHaproxyOCIImage)
+		WithImage(defaultHaproxyOCIImage).
+		WithSymlinks(defaultHaproxyOCISymlinks).
+		WithConfig(defaultHaproxyOCIConfig)
 }
 
 var (
@@ -35,5 +37,17 @@ var (
 		Protocol: "oci",
 		Server:   "https://ghcr.io",
 		Alias:    "lxc/cluster-api-provider-incus/haproxy:v20230606-42a2262b",
+	}
+
+	// defaultHaproxyOCISymlinks is default symlinks for OCI haproxy containers
+	defaultHaproxyOCISymlinks = map[string]string{
+		// Incus will inject its own PID 1 init process unless the entrypoint is one of "/init", "/sbin/init", "/s6-init".
+		"/init": "/usr/sbin/haproxy",
+	}
+
+	// defaultHaproxyOCIConfig is default configuration for OCI haproxy containers
+	defaultHaproxyOCIConfig = map[string]string{
+		// Use the /init symlink to avoid the Incus entrypoint from preventing SIGUSR2 propagating to child processes.
+		"oci.entrypoint": "/init -W -db -f /usr/local/etc/haproxy/haproxy.cfg",
 	}
 )

--- a/internal/loadbalancer/manager_oci.go
+++ b/internal/loadbalancer/manager_oci.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strconv"
 
 	incus "github.com/lxc/incus/v6/client"
 	"github.com/lxc/incus/v6/shared/api"
@@ -105,19 +104,7 @@ func (l *managerOCI) Reconfigure(ctx context.Context) error {
 	}
 
 	log.FromContext(ctx).V(1).Info("Reloading haproxy configuration")
-	var haproxyPids []string
-	if _, response, err := l.lxcClient.GetInstanceFile(l.name, "/proc"); err != nil {
-		return fmt.Errorf("failed to list running processes in load balancer instance: %w", err)
-	} else {
-		for _, entry := range response.Entries {
-			if _, err := strconv.ParseUint(entry, 10, 64); err != nil {
-				continue
-			}
-			haproxyPids = append(haproxyPids, entry)
-		}
-	}
-
-	if err := l.lxcClient.RunCommand(ctx, l.name, append([]string{"kill", "--signal", "SIGUSR2"}, haproxyPids...), nil, nil, nil); err != nil {
+	if err := l.lxcClient.RunCommand(ctx, l.name, append([]string{"kill", "--signal", "SIGUSR2"}, "1"), nil, nil, nil); err != nil {
 		return fmt.Errorf("failed to send SIGUSR2 to haproxy pids: %w", err)
 	}
 


### PR DESCRIPTION
### Summary

When using the `oci` load balancer type, run haproxy as pid 1 (symlink as `/init` to prevent Incus from overriding the entrypoint).

This means that we can just `kill --signal SIGUSR2 1` to reload haproxy configuration. Previously, we manually iterated over all PIDs in the container instead, because the Incus entrypoint did not allow the signal to propagate to child processes