### PR TITLE
chore: more launch options work

### DIFF
--- a/cmd/exp/image-builder/run_stage_create_instance.go
+++ b/cmd/exp/image-builder/run_stage_create_instance.go
@@ -23,8 +23,11 @@ func (*stageCreateInstance) run(ctx context.Context) error {
 		return fmt.Errorf("failed to pick image source for base image %q: %w", cfg.baseImage, err)
 	}
 
-	launchOpts := instances.DefaultKubeadmLaunchOptions(api.InstanceType(cfg.instanceType), false, lxcClient.GetServerName(), false).
-		WithImage(image).
+	launchOpts := instances.KubeadmLaunchOptions(instances.KubeadmLaunchOptionsInput{
+		InstanceType: api.InstanceType(cfg.instanceType),
+		ServerName:   lxcClient.GetServerName(),
+	}).
+		MaybeWithImage(image).
 		WithProfiles(cfg.instanceProfiles)
 
 	// set size of root volume to 5GB for virtual machines

--- a/cmd/exp/image-builder/run_stage_validate_image.go
+++ b/cmd/exp/image-builder/run_stage_validate_image.go
@@ -28,7 +28,7 @@ func (*stageValidateKubeadmImage) run(ctx context.Context) error {
 	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("instance.name", instanceName))
 
 	launchOpts := (&lxc.LaunchOptions{}).
-		WithImage(api.InstanceSource{Type: "image", Alias: cfg.imageAlias}).
+		MaybeWithImage(api.InstanceSource{Type: "image", Alias: cfg.imageAlias}).
 		WithInstanceType(api.InstanceType(cfg.instanceType)).
 		WithProfiles(cfg.instanceProfiles)
 

--- a/internal/controller/lxcmachine/controller_util_launch_kind.go
+++ b/internal/controller/lxcmachine/controller_util_launch_kind.go
@@ -2,18 +2,15 @@ package lxcmachine
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
 
 	"github.com/google/go-containerregistry/pkg/crane"
-	"github.com/lxc/incus/v6/shared/api"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
 	"sigs.k8s.io/cluster-api/util"
 
 	infrav1 "github.com/lxc/cluster-api-provider-incus/api/v1alpha2"
-	"github.com/lxc/cluster-api-provider-incus/internal/cloudinit"
 	"github.com/lxc/cluster-api-provider-incus/internal/instances"
 	"github.com/lxc/cluster-api-provider-incus/internal/lxc"
 	"github.com/lxc/cluster-api-provider-incus/internal/utils"
@@ -49,55 +46,26 @@ func launchKindInstance(ctx context.Context, cluster *clusterv1.Cluster, lxcClus
 		}
 		imageSpec.Name = strings.ReplaceAll(imageSpec.Name, "VERSION", machineVersion)
 	}
-
-	image := api.InstanceSource{
-		Type:        "image",
-		Protocol:    imageSpec.Protocol,
-		Server:      imageSpec.Server,
-		Alias:       imageSpec.Name,
-		Fingerprint: imageSpec.Fingerprint,
-	}
 	if imageSpec.IsZero() {
 		if machineVersion == "" {
 			return nil, utils.TerminalError(fmt.Errorf("no image source specified on LXCMachineTemplate and Machine %q does not have a Kubernetes version", machine.Name))
-		}
-
-		// test if kindest/node image for this version exists on DockerHub, fail otherwise.
-		if _, err := crane.Head(fmt.Sprintf("docker.io/kindest/node:%s", machineVersion)); err != nil {
-			// example errors:
-			// HEAD https://index.docker.io/v2/kindest/node/manifests/v1.34.0-not-exist: unexpected status code 404 Not Found (HEAD responses have no body, use GET for details)
-			// HEAD https://index.docker.io/v2/kindest/node13131/manifests/v1.33.0: unexpected status code 401 Unauthorized (HEAD responses have no body, use GET for details)
-			// HEAD http://w00:5050/v2/kindest/node13131/manifests/v1.33.0: unexpected status code 404 Not Found (HEAD responses have no body, use GET for details)
-			if strings.Contains(err.Error(), "unexpected status code 4") {
-				return nil, utils.TerminalError(fmt.Errorf("no image source specified and could not find kindest/node:%s image on DockerHub: %w. Please consider using a different Kubernetes version, or build your own base image and set the image source on the LXCMachineTemplate resource", machineVersion, err))
-			} else {
-				return nil, fmt.Errorf("no image source specified and failed to connect to DockerHub: %w", err)
+		} else {
+			// test if kindest/node image for this version exists on DockerHub, fail otherwise.
+			if _, err := crane.Head(fmt.Sprintf("docker.io/kindest/node:%s", machineVersion)); err != nil {
+				// example errors:
+				// HEAD https://index.docker.io/v2/kindest/node/manifests/v1.34.0-not-exist: unexpected status code 404 Not Found (HEAD responses have no body, use GET for details)
+				// HEAD https://index.docker.io/v2/kindest/node13131/manifests/v1.33.0: unexpected status code 401 Unauthorized (HEAD responses have no body, use GET for details)
+				// HEAD http://w00:5050/v2/kindest/node13131/manifests/v1.33.0: unexpected status code 404 Not Found (HEAD responses have no body, use GET for details)
+				if strings.Contains(err.Error(), "unexpected status code 4") {
+					return nil, utils.TerminalError(fmt.Errorf("no image source specified and could not find kindest/node:%s image on DockerHub: %w. Please consider using a different Kubernetes version, or build your own base image and set the image source on the LXCMachineTemplate resource", machineVersion, err))
+				} else {
+					return nil, fmt.Errorf("no image source specified and failed to connect to DockerHub: %w", err)
+				}
 			}
-		}
-
-		image = api.InstanceSource{
-			Type:     "image",
-			Protocol: "oci",
-			Server:   "https://docker.io",
-			Alias:    fmt.Sprintf("kindest/node:%s", machineVersion),
 		}
 	}
 
-	launchOpts := instances.DefaultKindLaunchOptions(!lxcCluster.Spec.Unprivileged, lxcCluster.Spec.SkipDefaultKubeadmProfile).
-		WithImage(image).
-		WithFlavor(lxcMachine.Spec.Flavor).
-		WithProfiles(lxcMachine.Spec.Profiles).
-		WithDevices(devices).
-		WithConfig(lxcMachine.Spec.Config).
-		WithConfig(map[string]string{
-			"user.cluster-name":      cluster.Name,
-			"user.cluster-namespace": cluster.Namespace,
-			"user.machine-name":      machine.Name,
-			"user.cluster-role":      role,
-			"cloud-init.user-data":   cloudInit,
-		})
-
-	// configure cloud-init
+	// avoid apt install cloud-init (and run cloud-init manually) unless requested
 	aptInstallCloudInit := false
 	if v, ok := lxcMachine.Spec.Config["user.capn.x-kind-apt-install-cloud-init"]; ok {
 		if b, err := strconv.ParseBool(v); err != nil {
@@ -107,38 +75,31 @@ func launchKindInstance(ctx context.Context, cluster *clusterv1.Cluster, lxcClus
 		}
 	}
 
-	if !aptInstallCloudInit {
-		// manual cloud-init mode:
-		// - parse YAML (ensure no unknown fields are present), and replace {{ v1.local_hostname }} with hostname
-		// - marshal to JSON
-		// - embed to instance at /hack/cloud-init.json
-		// - instance will run using the kind-cloud-init.py script (see internal/embed/kind-cloud-init.py)
-		cloudConfig, err := cloudinit.Parse(cloudInit, strings.NewReplacer(
-			"{{ v1.local_hostname }}", name,
-		))
-		if err != nil {
-			return nil, utils.TerminalError(fmt.Errorf("failed to parse instance cloud-config, please report this bug to https://github.com/lxc/cluster-api-provider-incus/issues: %w", err))
-		}
+	launchOpts, err := instances.KindLaunchOptions(instances.KindLaunchOptionsInput{
+		KubernetesVersion: machineVersion,
+		Privileged:        !lxcCluster.Spec.Unprivileged,
+		SkipProfile:       lxcCluster.Spec.SkipDefaultKubeadmProfile,
 
-		b, err := json.Marshal(cloudConfig)
-		if err != nil {
-			return nil, utils.TerminalError(fmt.Errorf("failed to generate JSON cloud-config for instance, please report this bug to github.com/lxc/cluster-api-provider-incus/issues: %w", err))
-		}
+		PodNetworkCIDR: utils.ClusterFirstPodNetworkCIDR(cluster),
 
-		launchOpts = launchOpts.WithSeedFiles(map[string]string{
-			"/hack/cloud-init.json": string(b),
+		CloudInit:           cloudInit,
+		CloudInitAptInstall: aptInstallCloudInit,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate kind instance launch options: %w", err)
+	}
+
+	launchOpts = launchOpts.
+		WithFlavor(lxcMachine.Spec.Flavor).
+		WithProfiles(lxcMachine.Spec.Profiles).
+		WithDevices(devices).
+		WithConfig(lxcMachine.Spec.Config).
+		WithConfig(map[string]string{
+			"user.cluster-name":      cluster.Name,
+			"user.cluster-namespace": cluster.Namespace,
+			"user.machine-name":      machine.Name,
+			"user.cluster-role":      role,
 		})
-	}
-
-	if nwk := cluster.Spec.ClusterNetwork; nwk != nil {
-		if pods := nwk.Pods; pods != nil {
-			if len(pods.CIDRBlocks) > 0 {
-				launchOpts = launchOpts.WithReplacements(map[string]*strings.Replacer{
-					"/kind/manifests/default-cni.yaml": strings.NewReplacer("{{ .PodSubnet }}", pods.CIDRBlocks[0]),
-				})
-			}
-		}
-	}
 
 	return lxcClient.WithTarget(lxcMachine.Spec.Target).WaitForLaunchInstance(ctx, name, launchOpts)
 }

--- a/internal/instances/haproxy.go
+++ b/internal/instances/haproxy.go
@@ -6,48 +6,35 @@ import (
 	"github.com/lxc/cluster-api-provider-incus/internal/lxc"
 )
 
-// DefaultHaproxyLXCLaunchOptions is default options for LXC haproxy load balancer containers
-func DefaultHaproxyLXCLaunchOptions() *lxc.LaunchOptions {
+// HaproxyLXCLaunchOptions launches LXC haproxy load balancer containers.
+func HaproxyLXCLaunchOptions() *lxc.LaunchOptions {
 	return (&lxc.LaunchOptions{}).
 		WithInstanceType(api.InstanceTypeContainer).
-		WithImage(defaultHaproxyLXCImage)
+		MaybeWithImage(api.InstanceSource{
+			Type:     "image",
+			Protocol: "simplestreams",
+			Server:   lxc.DefaultSimplestreamsServer,
+			Alias:    "haproxy",
+		})
 }
 
-// DefaultHaproxyOCILaunchOptions is default options for OCI haproxy load balancer containers
-func DefaultHaproxyOCILaunchOptions() *lxc.LaunchOptions {
+// HaproxyOCILaunchOptions launches OCI haproxy load balancer containers.
+func HaproxyOCILaunchOptions() *lxc.LaunchOptions {
 	return (&lxc.LaunchOptions{}).
 		WithInstanceType(api.InstanceTypeContainer).
-		WithImage(defaultHaproxyOCIImage).
-		WithSymlinks(defaultHaproxyOCISymlinks).
-		WithConfig(defaultHaproxyOCIConfig)
+		MaybeWithImage(api.InstanceSource{
+			Type:     "image",
+			Protocol: "oci",
+			Server:   "https://ghcr.io",
+			Alias:    "lxc/cluster-api-provider-incus/haproxy:v20230606-42a2262b",
+		}).
+		WithSymlinks(map[string]string{
+			// Incus will inject its own PID 1 init process unless the entrypoint is one of "/init", "/sbin/init", "/s6-init".
+			"/init": "/usr/sbin/haproxy",
+		}).
+		WithConfig(map[string]string{
+			// Use the /init symlink to avoid the Incus entrypoint from preventing SIGUSR2 propagating to child processes.
+			"oci.entrypoint": "/init -W -db -f /usr/local/etc/haproxy/haproxy.cfg",
+		})
+
 }
-
-var (
-	// defaultHaproxyLXCImage is the default image for LXC haproxy containers
-	defaultHaproxyLXCImage = api.InstanceSource{
-		Type:     "image",
-		Protocol: "simplestreams",
-		Server:   lxc.DefaultSimplestreamsServer,
-		Alias:    "haproxy",
-	}
-
-	// defaultHaproxyOCIImage is the default image for OCI haproxy containers
-	defaultHaproxyOCIImage = api.InstanceSource{
-		Type:     "image",
-		Protocol: "oci",
-		Server:   "https://ghcr.io",
-		Alias:    "lxc/cluster-api-provider-incus/haproxy:v20230606-42a2262b",
-	}
-
-	// defaultHaproxyOCISymlinks is default symlinks for OCI haproxy containers
-	defaultHaproxyOCISymlinks = map[string]string{
-		// Incus will inject its own PID 1 init process unless the entrypoint is one of "/init", "/sbin/init", "/s6-init".
-		"/init": "/usr/sbin/haproxy",
-	}
-
-	// defaultHaproxyOCIConfig is default configuration for OCI haproxy containers
-	defaultHaproxyOCIConfig = map[string]string{
-		// Use the /init symlink to avoid the Incus entrypoint from preventing SIGUSR2 propagating to child processes.
-		"oci.entrypoint": "/init -W -db -f /usr/local/etc/haproxy/haproxy.cfg",
-	}
-)

--- a/internal/instances/kind.go
+++ b/internal/instances/kind.go
@@ -1,53 +1,106 @@
 package instances
 
 import (
+	"encoding/json"
+	"fmt"
 	"strings"
 
 	"github.com/lxc/incus/v6/shared/api"
 
+	"github.com/lxc/cluster-api-provider-incus/internal/cloudinit"
 	"github.com/lxc/cluster-api-provider-incus/internal/lxc"
 	"github.com/lxc/cluster-api-provider-incus/internal/static"
+	"github.com/lxc/cluster-api-provider-incus/internal/utils"
 )
 
-// DefaultKindLaunchOptions is default seed files and mutations required for kindest/node images.
-func DefaultKindLaunchOptions(privileged bool, skipProfile bool) *lxc.LaunchOptions {
+type KindLaunchOptionsInput struct {
+	KubernetesVersion string
+
+	Privileged  bool
+	SkipProfile bool
+
+	PodNetworkCIDR string
+
+	CloudInit           string
+	CloudInitAptInstall bool
+}
+
+// KindLaunchOptions launches kindest/node nodes.
+func KindLaunchOptions(in KindLaunchOptionsInput) (*lxc.LaunchOptions, error) {
 	opts := (&lxc.LaunchOptions{}).
 		WithInstanceType(api.InstanceTypeContainer).
-		WithSeedFiles(defaultKindSeedFiles).
-		WithReplacements(defaultKindReplacements).
-		WithSymlinks(defaultKindSymlinks)
+		MaybeWithImage(api.InstanceSource{
+			Type:     "image",
+			Protocol: "oci",
+			Server:   "https://docker.io",
+			Alias:    fmt.Sprintf("kindest/node:%s", in.KubernetesVersion),
+		}).
+		WithReplacements(map[string]*strings.Replacer{
+			// Incus unprivileged containers cannot edit /etc/resolv.conf, so do not let the entrypoint attempt it.
+			"/usr/local/bin/entrypoint": strings.NewReplacer(">/etc/resolv.conf", ">/etc/local-resolv.conf"),
+		}).
+		WithSymlinks(map[string]string{
+			// Incus will inject its own PID 1 init process unless the entrypoint is one of "/init", "/sbin/init", "/s6-init".
+			"/init": "/usr/local/bin/entrypoint",
+		})
+
+	// add cloud-init configuration as nocloud-net datasource in the instance
+	if len(in.CloudInit) > 0 {
+		opts = opts.
+			WithConfig(map[string]string{
+				"cloud-init.user-data": in.CloudInit,
+			}).
+			WithSeedFiles(map[string]string{
+				// inject cloud-init into instance.
+				"/var/lib/cloud/seed/nocloud-net/meta-data": static.CloudInitMetaDataTemplate(),
+				"/var/lib/cloud/seed/nocloud-net/user-data": static.CloudInitUserDataTemplate(),
+				// cloud-init-launch.service is used to start the cloud-init scripts.
+				"/etc/systemd/system/cloud-init-launch.service": static.CloudInitLaunchSystemdServiceTemplate(),
+				"/hack/cloud-init.py":                           static.KindCloudInitScript(),
+			}).
+			WithSymlinks(map[string]string{
+				// enable the cloud-init-launch service.
+				"/etc/systemd/system/multi-user.target.wants/cloud-init-launch.service": "/etc/systemd/system/cloud-init-launch.service",
+			})
+
+		if !in.CloudInitAptInstall {
+			// manual cloud-init mode:
+			// - parse YAML (ensure no unknown fields are present), and replace "{{ v1.local_hostname }}" with "{{ container.name }}", which is a pango template that will resolve to the instance hostname upon launch
+			// - marshal to JSON
+			// - embed to instance at /hack/cloud-init.json
+			// - instance will run using the kind-cloud-init.py script (see internal/embed/kind-cloud-init.py)
+			cloudConfig, err := cloudinit.Parse(in.CloudInit, strings.NewReplacer(
+				"{{ v1.local_hostname }}", "{{ container.name }}",
+			))
+			if err != nil {
+				return nil, utils.TerminalError(fmt.Errorf("failed to parse instance cloud-config, please report this bug to https://github.com/lxc/cluster-api-provider-incus/issues: %w", err))
+			}
+
+			b, err := json.Marshal(cloudConfig)
+			if err != nil {
+				return nil, utils.TerminalError(fmt.Errorf("failed to generate JSON cloud-config for instance, please report this bug to github.com/lxc/cluster-api-provider-incus/issues: %w", err))
+			}
+
+			opts = opts.WithSeedFiles(map[string]string{
+				"/hack/cloud-init.json": string(b),
+			})
+		}
+	}
+
+	// pod network CIDR
+	if len(in.PodNetworkCIDR) > 0 {
+		opts = opts.WithReplacements(map[string]*strings.Replacer{
+			"/kind/manifests/default-cni.yaml": strings.NewReplacer("{{ .PodSubnet }}", in.PodNetworkCIDR),
+		})
+	}
 
 	// apply profile for Kubernetes to run in LXC containers
-	if !skipProfile {
-		profile := static.DefaultKindProfile(privileged)
+	if !in.SkipProfile {
+		profile := static.DefaultKindProfile(in.Privileged)
 		opts = opts.
 			WithConfig(profile.Config).
 			WithDevices(profile.Devices)
 	}
 
-	return opts
-}
-
-// defaultKindSeedFiles that are injected to LXCMachine kind instances.
-var defaultKindSeedFiles = map[string]string{
-	// inject cloud-init into instance.
-	"/var/lib/cloud/seed/nocloud-net/meta-data": static.CloudInitMetaDataTemplate(),
-	"/var/lib/cloud/seed/nocloud-net/user-data": static.CloudInitUserDataTemplate(),
-	// cloud-init-launch.service is used to start the cloud-init scripts.
-	"/etc/systemd/system/cloud-init-launch.service": static.CloudInitLaunchSystemdServiceTemplate(),
-	"/hack/cloud-init.py":                           static.KindCloudInitScript(),
-}
-
-// defaultKindSymlinks that are injected to LXCMachine kind instances.
-var defaultKindSymlinks = map[string]string{
-	// Incus will inject its own PID 1 init process unless the entrypoint is one of "/init", "/sbin/init", "/s6-init".
-	"/init": "/usr/local/bin/entrypoint",
-	// Enable the cloud-init-launch service.
-	"/etc/systemd/system/multi-user.target.wants/cloud-init-launch.service": "/etc/systemd/system/cloud-init-launch.service",
-}
-
-// defaultKindReplacements that are performed to LXCMachine kind instances.
-var defaultKindReplacements = map[string]*strings.Replacer{
-	// Incus unprivileged containers cannot edit /etc/resolv.conf, so do not let the entrypoint attempt it.
-	"/usr/local/bin/entrypoint": strings.NewReplacer(">/etc/resolv.conf", ">/etc/local-resolv.conf"),
+	return opts, nil
 }

--- a/internal/loadbalancer/manager_oci.go
+++ b/internal/loadbalancer/manager_oci.go
@@ -35,24 +35,21 @@ func (l *managerOCI) Create(ctx context.Context) ([]string, error) {
 		return nil, fmt.Errorf("server does not support OCI containers: %w", err)
 	}
 
-	launchOpts := instances.DefaultHaproxyOCILaunchOptions().
+	launchOpts := instances.HaproxyOCILaunchOptions().
 		WithProfiles(l.spec.Profiles).
 		WithFlavor(l.spec.Flavor).
 		WithConfig(map[string]string{
 			"user.cluster-name":      l.clusterName,
 			"user.cluster-namespace": l.clusterNamespace,
 			"user.cluster-role":      "loadbalancer",
-		})
-
-	if !l.spec.Image.IsZero() {
-		launchOpts = launchOpts.WithImage(api.InstanceSource{
+		}).
+		MaybeWithImage(api.InstanceSource{
 			Type:        "image",
 			Protocol:    l.spec.Image.Protocol,
 			Server:      l.spec.Image.Server,
 			Alias:       l.spec.Image.Name,
 			Fingerprint: l.spec.Image.Fingerprint,
 		})
-	}
 
 	log.FromContext(ctx).V(1).Info("Launching load balancer instance")
 	addrs, err := l.lxcClient.WithTarget(l.spec.Target).WaitForLaunchInstance(ctx, l.name, launchOpts)

--- a/internal/lxc/client_instances_launch_options.go
+++ b/internal/lxc/client_instances_launch_options.go
@@ -89,9 +89,12 @@ func (o *LaunchOptions) WithProfiles(new []string) *LaunchOptions {
 	return o
 }
 
-// WithImage sets the instance image.
-func (o *LaunchOptions) WithImage(image api.InstanceSource) *LaunchOptions {
-	o.image = image
+// MaybeWithImage sets the instance image.
+// MaybeWithImage is a no-op if no alias or fingerprint are specified on the image.
+func (o *LaunchOptions) MaybeWithImage(image api.InstanceSource) *LaunchOptions {
+	if len(image.Alias) != 0 || len(image.Fingerprint) != 0 {
+		o.image = image
+	}
 	return o
 }
 

--- a/internal/utils/pod_cidr.go
+++ b/internal/utils/pod_cidr.go
@@ -1,0 +1,14 @@
+package utils
+
+import clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+
+func ClusterFirstPodNetworkCIDR(in *clusterv1.Cluster) string {
+	if nwk := in.Spec.ClusterNetwork; nwk != nil {
+		if pods := nwk.Pods; pods != nil {
+			if len(pods.CIDRBlocks) > 0 {
+				return pods.CIDRBlocks[0]
+			}
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

More work similar to #129 #130, in preparation for kini work.

## Changes

- use structured inputs for instance types
- set cloud init as input in instance type
- move all kind cloud-init code in the launch options
- cleanup launch instance code

<!--