### PR TITLE
chore: use klog flags for tool logging

### DIFF
--- a/cmd/exp/image-builder/main.go
+++ b/cmd/exp/image-builder/main.go
@@ -4,15 +4,13 @@ import (
 	"context"
 	"os"
 
-	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 var (
-	gCtx       context.Context
-	gLogger    = ctrl.Log
-	logOptions = logs.NewOptions()
+	gCtx    context.Context
+	gLogger = ctrl.Log
 )
 
 func main() {

--- a/cmd/exp/simplestreams/cmd_root.go
+++ b/cmd/exp/simplestreams/cmd_root.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	cliflag "k8s.io/component-base/cli/flag"
-	logsv1 "k8s.io/component-base/logs/api/v1"
+	"k8s.io/klog/v2"
 )
 
 var (
@@ -19,10 +19,6 @@ var (
 		Use:          "simplestreams",
 		SilenceUsage: true,
 		PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-			if err := logsv1.ValidateAndApply(logOptions, nil); err != nil {
-				return fmt.Errorf("failed to configure logging: %w", err)
-			}
-
 			if cfg.rootDir == "" {
 				log.V(1).Info("--root-dir not specified, using current directory")
 				if dir, err := os.Getwd(); err != nil {
@@ -38,18 +34,17 @@ var (
 )
 
 func init() {
-	logsv1.AddFlags(logOptions, rootCmd.PersistentFlags())
-	rootCmd.SetGlobalNormalizationFunc(cliflag.WordSepNormalizeFunc)
-	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
-
-	_ = rootCmd.PersistentFlags().MarkHidden("kubeconfig")
-	_ = rootCmd.PersistentFlags().MarkHidden("log-text-info-buffer-size")
-	_ = rootCmd.PersistentFlags().MarkHidden("log-flush-frequency")
-	_ = rootCmd.PersistentFlags().MarkHidden("log-text-split-stream")
-	_ = rootCmd.PersistentFlags().MarkHidden("logging-format")
-
 	rootCmd.AddGroup(&cobra.Group{ID: "operations", Title: "Available operations:"})
 	rootCmd.AddCommand(importCmd, showCmd)
+
+	rootCmd.SetGlobalNormalizationFunc(cliflag.WordSepNormalizeFunc)
+
+	// logging flags
+	klog.InitFlags(nil)
+	flag.CommandLine.VisitAll(func(f *flag.Flag) {
+		f.Usage = "[logging] " + f.Usage
+	})
+	rootCmd.PersistentFlags().AddGoFlagSet(flag.CommandLine)
 
 	rootCmd.PersistentFlags().StringVar(&cfg.rootDir, "root-dir", "",
 		"Simplestreams index directory")

--- a/cmd/exp/simplestreams/main.go
+++ b/cmd/exp/simplestreams/main.go
@@ -4,15 +4,13 @@ import (
 	"context"
 	"os"
 
-	"k8s.io/component-base/logs"
 	"k8s.io/klog/v2"
 	ctrl "sigs.k8s.io/controller-runtime"
 )
 
 var (
-	ctx        context.Context
-	log        = ctrl.Log
-	logOptions = logs.NewOptions()
+	ctx context.Context
+	log = ctrl.Log
 )
 
 func main() {


### PR DESCRIPTION
## Summary

switch to klog flags for all logging configuration. this is preliminary cleanup work for kini