### PR TITLE
fix e2e CI flakes with kind cni manifests

### DIFF
--- a/test/e2e/data/config.yaml
+++ b/test/e2e/data/config.yaml
@@ -139,3 +139,6 @@ intervals:
 
   # [Autoscaler] wait for autoscaler operations
   default/wait-autoscaler: ["5m", "10s"]
+
+  # [QuickStart Kind] wait for kind cni manifests
+  default/wait-kind-cni: ["1m", "5s"]


### PR DESCRIPTION
### Summary

Attempt to fix e2e test flakes related to kind CNI failing to be applied.