### PR TITLE
chore: pre-fetch system images before running tests

### DIFF
--- a/internal/instances/haproxy.go
+++ b/internal/instances/haproxy.go
@@ -12,7 +12,7 @@ func HaproxyLXCLaunchOptions() *lxc.LaunchOptions {
 		WithInstanceType(api.InstanceTypeContainer).
 		MaybeWithImage(api.InstanceSource{
 			Type:     "image",
-			Protocol: "simplestreams",
+			Protocol: lxc.Simplestreams,
 			Server:   lxc.DefaultSimplestreamsServer,
 			Alias:    "haproxy",
 		})
@@ -24,7 +24,7 @@ func HaproxyOCILaunchOptions() *lxc.LaunchOptions {
 		WithInstanceType(api.InstanceTypeContainer).
 		MaybeWithImage(api.InstanceSource{
 			Type:     "image",
-			Protocol: "oci",
+			Protocol: lxc.OCI,
 			Server:   "https://ghcr.io",
 			Alias:    "lxc/cluster-api-provider-incus/haproxy:v20230606-42a2262b",
 		}).

--- a/internal/instances/kubeadm.go
+++ b/internal/instances/kubeadm.go
@@ -27,7 +27,7 @@ func KubeadmLaunchOptions(in KubeadmLaunchOptionsInput) *lxc.LaunchOptions {
 		WithInstanceType(in.InstanceType).
 		MaybeWithImage(api.InstanceSource{
 			Type:     "image",
-			Protocol: "simplestreams",
+			Protocol: lxc.Simplestreams,
 			Server:   lxc.DefaultSimplestreamsServer,
 			Alias:    fmt.Sprintf("kubeadm/%s", in.KubernetesVersion),
 		}).

--- a/internal/lxc/client_parse_image.go
+++ b/internal/lxc/client_parse_image.go
@@ -13,6 +13,7 @@ import (
 
 type imageInfo struct {
 	server    string
+	protocol  string
 	transform func(in string) string
 }
 
@@ -22,44 +23,59 @@ var (
 		Incus: {
 			"ubuntu": { // "ubuntu:24.04" -> "ubuntu/24.04/cloud" from "https://images.linuxcontainers.org"
 				server:    DefaultIncusSimplestreamsServer,
+				protocol:  Simplestreams,
 				transform: func(in string) string { return fmt.Sprintf("ubuntu/%s/cloud", in) },
 			},
 			"debian": { // "debian:12" -> "debian/12/cloud" from "https://images.linuxcontainers.org"
 				server:    DefaultIncusSimplestreamsServer,
+				protocol:  Simplestreams,
 				transform: func(in string) string { return fmt.Sprintf("debian/%s/cloud", in) },
 			},
 			"images": { // "images:IMAGE" -> "IMAGE" from "https://images.linuxcontainers.org"
 				server:    DefaultIncusSimplestreamsServer,
+				protocol:  Simplestreams,
 				transform: func(in string) string { return in },
 			},
 			"capi": { // "capi:IMAGE" -> "IMAGE" from "https://d14dnvi2l3tc5t.cloudfront.net"
 				server:    DefaultSimplestreamsServer,
+				protocol:  Simplestreams,
 				transform: func(in string) string { return in },
 			},
 			"capi-stg": { // "capi-stg:IMAGE" -> "IMAGE" from "https://djapqxqu5n2qu.cloudfront.net"
 				server:    DefaultStagingSimplestreamsServer,
+				protocol:  Simplestreams,
 				transform: func(in string) string { return in },
+			},
+			"kind": { // "kind:VERSION" -> "kindest/node:VERSION" from "https://docker.io"
+				server:    DockerHubServer,
+				protocol:  OCI,
+				transform: func(in string) string { return fmt.Sprintf("kindest/node:%s", in) },
 			},
 		},
 		LXD: {
 			"ubuntu": { // "ubuntu:24.04" -> "24.04" from "https://cloud-images.ubuntu.com/releases/"
 				server:    DefaultLXDUbuntuSimplestreamsServer,
+				protocol:  Simplestreams,
 				transform: func(in string) string { return in },
 			},
 			"debian": { // "debian:12" -> "debian/12/cloud" from "https://images.lxd.canonical.com"
 				server:    DefaultLXDSimplestreamsServer,
+				protocol:  Simplestreams,
 				transform: func(in string) string { return fmt.Sprintf("debian/%s/cloud", in) },
 			},
 			"images": { // "images:IMAGE" -> "IMAGE" from "https://images.lxd.canonical.com"
 				server:    DefaultLXDSimplestreamsServer,
+				protocol:  Simplestreams,
 				transform: func(in string) string { return in },
 			},
 			"capi": { // "capi:IMAGE" -> "IMAGE" from "https://d14dnvi2l3tc5t.cloudfront.net"
 				server:    DefaultSimplestreamsServer,
+				protocol:  Simplestreams,
 				transform: func(in string) string { return in },
 			},
 			"capi-stg": { // "capi-stg:IMAGE" -> "IMAGE" from "https://djapqxqu5n2qu.cloudfront.net"
 				server:    DefaultStagingSimplestreamsServer,
+				protocol:  Simplestreams,
 				transform: func(in string) string { return in },
 			},
 		},
@@ -75,7 +91,7 @@ func TryParseImageSource(serverName, imageName string) (api.InstanceSource, bool
 	if info, ok := wellKnownImagePrefixes[serverName][parts[0]]; ok {
 		return api.InstanceSource{
 			Type:     "image",
-			Protocol: "simplestreams",
+			Protocol: info.protocol,
 			Server:   info.server,
 			Alias:    info.transform(parts[1]),
 		}, true, nil

--- a/internal/lxc/client_parse_image_test.go
+++ b/internal/lxc/client_parse_image_test.go
@@ -20,6 +20,15 @@ func simplestreamsImage(server string, name string) api.InstanceSource {
 	}
 }
 
+func ociImage(server string, name string) api.InstanceSource {
+	return api.InstanceSource{
+		Type:     "image",
+		Protocol: "oci",
+		Server:   server,
+		Alias:    name,
+	}
+}
+
 func TestTryParseImageSource(t *testing.T) {
 	for _, tc := range []struct {
 		server            string
@@ -36,6 +45,7 @@ func TestTryParseImageSource(t *testing.T) {
 		{server: "incus", image: "images:almalinux/9/cloud", expectParsed: true, expectImageSource: simplestreamsImage("https://images.linuxcontainers.org", "almalinux/9/cloud")},
 		{server: "incus", image: "capi:kubeadm/v1.33.0", expectParsed: true, expectImageSource: simplestreamsImage("https://d14dnvi2l3tc5t.cloudfront.net", "kubeadm/v1.33.0")},
 		{server: "incus", image: "capi-stg:kubeadm/v1.33.0", expectParsed: true, expectImageSource: simplestreamsImage("https://djapqxqu5n2qu.cloudfront.net", "kubeadm/v1.33.0")},
+		{server: "incus", image: "kind:v1.33.0", expectParsed: true, expectImageSource: ociImage("https://docker.io", "kindest/node:v1.33.0")},
 		// verify lxd prefixes
 		{server: "lxd", image: "image-name"},
 		{server: "lxd", image: "unknown:image", expectErr: true},
@@ -44,6 +54,7 @@ func TestTryParseImageSource(t *testing.T) {
 		{server: "lxd", image: "images:almalinux/9/cloud", expectParsed: true, expectImageSource: simplestreamsImage("https://images.lxd.canonical.com", "almalinux/9/cloud")},
 		{server: "lxd", image: "capi:kubeadm/v1.33.0", expectParsed: true, expectImageSource: simplestreamsImage("https://d14dnvi2l3tc5t.cloudfront.net", "kubeadm/v1.33.0")},
 		{server: "lxd", image: "capi-stg:kubeadm/v1.33.0", expectParsed: true, expectImageSource: simplestreamsImage("https://djapqxqu5n2qu.cloudfront.net", "kubeadm/v1.33.0")},
+		{server: "lxd", image: "kind:v1.33.0", expectErr: true},
 		// verify prefixes for unknown
 		{server: "unknown", image: "image-name"},
 		{server: "unknown", image: "ubuntu:24.04", expectErr: true},

--- a/internal/lxc/consts.go
+++ b/internal/lxc/consts.go
@@ -18,6 +18,9 @@ const (
 	// DefaultLXDUbuntuSimplestreamsServer is the default simplestreams server for Ubuntu images for Canonical LXD.
 	DefaultLXDUbuntuSimplestreamsServer = "https://cloud-images.ubuntu.com/releases/"
 
+	// DockerHubServer is the server URL for DockerHub images.
+	DockerHubServer = "https://docker.io"
+
 	// Container is the instance type for container instances.
 	Container = "container"
 
@@ -29,6 +32,12 @@ const (
 
 	// LXD is the server name for Canonical LXD servers.
 	LXD = "lxd"
+
+	// OCI is the protocol for OCI images.
+	OCI = "oci"
+
+	// Simplestreams is the protocol for Simplestreams images.
+	Simplestreams = "simplestreams"
 
 	// instanceCreateTimeout is the timeout for creating an instance.
 	instanceCreateTimeout = 180 * time.Second

--- a/test/e2e/shared/defaults.go
+++ b/test/e2e/shared/defaults.go
@@ -30,8 +30,10 @@ import (
 )
 
 const (
-	KubeContext       = "KUBE_CONTEXT"
-	KubernetesVersion = "KUBERNETES_VERSION"
+	KubeContext                  = "KUBE_CONTEXT"
+	KubernetesVersion            = "KUBERNETES_VERSION"
+	KubernetesVersionUpgradeFrom = "KUBERNETES_VERSION_UPGRADE_FROM"
+	KubernetesVersionUpgradeTo   = "KUBERNETES_VERSION_UPGRADE_TO"
 
 	// Load LXC server credentials from local config file
 	LXCLoadConfigFile = "LXC_LOAD_CONFIG_FILE"
@@ -49,6 +51,9 @@ const (
 	FlavorDefault     = ""
 	FlavorDevelopment = "development"
 	FlavorAutoscaler  = "autoscaler"
+
+	UbuntuImage = "ubuntu:24.04"
+	DebianImage = "debian:13"
 )
 
 // DefaultScheme returns the default scheme to use for testing.

--- a/test/e2e/shared/images.go
+++ b/test/e2e/shared/images.go
@@ -1,0 +1,57 @@
+//go:build e2e
+
+package shared
+
+import (
+	"context"
+	"fmt"
+
+	incus "github.com/lxc/incus/v6/client"
+	"github.com/lxc/incus/v6/shared/api"
+	"sigs.k8s.io/cluster-api/test/e2e"
+
+	"github.com/lxc/cluster-api-provider-incus/internal/lxc"
+
+	. "github.com/onsi/gomega"
+)
+
+// defaultImages to download before running the e2e tests.
+func defaultImages(e2eCtx *E2EContext, serverName string) []string {
+	images := []string{
+		UbuntuImage,
+		DebianImage,
+		fmt.Sprintf("capi:kubeadm/%s", e2eCtx.E2EConfig.MustGetVariable(KubernetesVersion)),
+		fmt.Sprintf("capi:kubeadm/%s", e2eCtx.E2EConfig.MustGetVariable(KubernetesVersionUpgradeFrom)),
+		fmt.Sprintf("capi:kubeadm/%s", e2eCtx.E2EConfig.MustGetVariable(KubernetesVersionUpgradeTo)),
+	}
+	if serverName == lxc.Incus {
+		images = append(images, fmt.Sprintf("kind:%s", e2eCtx.E2EConfig.MustGetVariable(KubernetesVersion)))
+	}
+	return images
+}
+
+func ensureLXCSystemImages(e2eCtx *E2EContext) {
+	lxcClient, err := lxc.New(context.TODO(), e2eCtx.Settings.LXCClientOptions)
+	Expect(err).ToNot(HaveOccurred(), "Failed to initialize client")
+
+	for _, imageName := range defaultImages(e2eCtx, lxcClient.GetServerName()) {
+		e2e.Byf("Fetching image %s", imageName)
+
+		image, parsed, err := lxc.TryParseImageSource(lxcClient.GetServerName(), imageName)
+		Expect(err).ToNot(HaveOccurred(), "Image must be recognized")
+		Expect(parsed).To(BeTrue(), "Image prefix not recognized")
+
+		Expect(lxcClient.WaitForOperation(context.TODO(), fmt.Sprintf("CreateImage(%s)", imageName), func() (incus.Operation, error) {
+			return lxcClient.CreateImage(api.ImagesPost{
+				Source: &api.ImagesPostSource{
+					Type: "image",
+					ImageSource: api.ImageSource{
+						Alias:    image.Alias,
+						Protocol: image.Protocol,
+						Server:   image.Server,
+					},
+				},
+			}, nil)
+		})).ToNot(HaveOccurred(), "Image pull failed")
+	}
+}

--- a/test/e2e/shared/suite.go
+++ b/test/e2e/shared/suite.go
@@ -69,6 +69,9 @@ func Node1BeforeSuite(ctx context.Context, e2eCtx *E2EContext) []byte {
 	Logf("Ensuring infrastructure credentials can be used")
 	ensureLXCClientOptions(e2eCtx)
 
+	Logf("Ensuring system images")
+	ensureLXCSystemImages(e2eCtx)
+
 	conf := synchronizedBeforeTestSuiteConfig{
 		E2EConfig:            *e2eCtx.E2EConfig,
 		ArtifactFolder:       e2eCtx.Settings.ArtifactFolder,

--- a/test/e2e/suites/e2e/quick_start_debian_test.go
+++ b/test/e2e/suites/e2e/quick_start_debian_test.go
@@ -20,7 +20,7 @@ var _ = Describe("QuickStart", func() {
 		BeforeEach(func(ctx context.Context) {
 			e2eCtx.OverrideVariables(map[string]string{
 				"KUBERNETES_VERSION": "v1.33.3", // Kubernetes version without pre-built images
-				"LXC_IMAGE_NAME":     "debian:13",
+				"LXC_IMAGE_NAME":     shared.DebianImage,
 				"INSTALL_KUBEADM":    "true",
 			})
 		})

--- a/test/e2e/suites/e2e/quick_start_ubuntu_test.go
+++ b/test/e2e/suites/e2e/quick_start_ubuntu_test.go
@@ -20,7 +20,7 @@ var _ = Describe("QuickStart", func() {
 		BeforeEach(func(ctx context.Context) {
 			e2eCtx.OverrideVariables(map[string]string{
 				"KUBERNETES_VERSION": "v1.33.3", // Kubernetes version without pre-built images
-				"LXC_IMAGE_NAME":     "ubuntu:24.04",
+				"LXC_IMAGE_NAME":     shared.UbuntuImage,
 				"INSTALL_KUBEADM":    "true",
 			})
 		})


### PR DESCRIPTION
### Summary

Noticing many e2e flakes recently due to instances not coming up, especially for LXD.

### Changes

- Build list of images to download before running tests, such that upstream failures are raised earlier instead of while running the tests
- Remove the time needed to pull the images from being accounted into the runtime of the test