### PR TITLE
image-builder: Make VM images compatible with both Incus and LXD

### DIFF
--- a/.github/workflows/build-kubeadm-images.yml
+++ b/.github/workflows/build-kubeadm-images.yml
@@ -15,20 +15,16 @@ jobs:
       matrix:
         include:
         # amd64 images
-        - { infrastructure: incus,  type: container,        base: ubuntu, arch: amd64 }
-        - { infrastructure: incus,  type: virtual-machine,  base: ubuntu, arch: amd64 }
-        - { infrastructure: lxd,    type: virtual-machine,  base: ubuntu, arch: amd64 }
-        - { infrastructure: incus,  type: container,        base: debian, arch: amd64 }
-        - { infrastructure: incus,  type: virtual-machine,  base: debian, arch: amd64 }
-        - { infrastructure: lxd,    type: virtual-machine,  base: debian, arch: amd64 }
+        - { type: container,        base: ubuntu, arch: amd64 }
+        - { type: virtual-machine,  base: ubuntu, arch: amd64 }
+        - { type: container,        base: debian, arch: amd64 }
+        - { type: virtual-machine,  base: debian, arch: amd64 }
 
         # arm64 images
-        - { infrastructure: incus,  type: container,        base: ubuntu, arch: arm64 }
-        # - { infrastructure: incus,  type: virtual-machine,  base: ubuntu, arch: arm64 }   # arm64 runners do not support kvm
-        # - { infrastructure: lxd,    type: virtual-machine,  base: ubuntu, arch: arm64 }   # arm64 runners do not support kvm
-        - { infrastructure: incus,  type: container,        base: debian,    arch: arm64 }
-        # - { infrastructure: incus,  type: virtual-machine,  base: debian,    arch: arm64 }   # arm64 runners do not support kvm
-        # - { infrastructure: lxd,    type: virtual-machine,  base: debian,    arch: arm64 }   # arm64 runners do not support kvm
+        - { type: container,        base: ubuntu, arch: arm64 }
+        # - { type: virtual-machine,  base: ubuntu, arch: arm64 }   # arm64 runners do not support kvm
+        - { type: container,        base: debian, arch: arm64 }
+        # - { type: virtual-machine,  base: debian, arch: arm64 }   # arm64 runners do not support kvm
     runs-on: ${{ matrix.arch == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     steps:
       - name: Checkout
@@ -41,7 +37,7 @@ jobs:
 
       - name: Setup infrastructure
         run: |
-          ./hack/scripts/ci/setup-${{ matrix.infrastructure }}.sh
+          ./hack/scripts/ci/setup-incus.sh
 
       - name: Build image
         run: |
@@ -49,10 +45,10 @@ jobs:
             --base-image=${{ matrix.base }} \
             --kubernetes-version=${{ inputs.version }} \
             --instance-type=${{ matrix.type }} \
-            --output=kubeadm-${{ inputs.version }}-${{ matrix.infrastructure }}-${{ matrix.type }}-${{ matrix.base }}-${{ matrix.arch }}.tar.gz
+            --output=kubeadm-${{ inputs.version }}-${{ matrix.type }}-${{ matrix.base }}-${{ matrix.arch }}.tar.gz
 
       - name: Upload image
         uses: actions/upload-artifact@v4
         with:
-          name: kubeadm-${{ inputs.version }}-${{ matrix.infrastructure }}-${{ matrix.type }}-${{ matrix.base }}-${{ matrix.arch }}
-          path: kubeadm-${{ inputs.version }}-${{ matrix.infrastructure }}-${{ matrix.type }}-${{ matrix.base }}-${{ matrix.arch }}.tar.gz
+          name: kubeadm-${{ inputs.version }}-${{ matrix.type }}-${{ matrix.base }}-${{ matrix.arch }}
+          path: kubeadm-${{ inputs.version }}-${{ matrix.type }}-${{ matrix.base }}-${{ matrix.arch }}.tar.gz

--- a/cmd/exp/simplestreams/internal/cmd/cmd_import_release.go
+++ b/cmd/exp/simplestreams/internal/cmd/cmd_import_release.go
@@ -15,9 +15,8 @@ func newImportReleaseCmd() *cobra.Command {
 
 		alias []string
 
-		containerImage string
-		vmImageIncus   string
-		vmImageLXD     string
+		containerImage      string
+		virtualMachineImage string
 	}
 
 	cmd := &cobra.Command{
@@ -36,15 +35,9 @@ func newImportReleaseCmd() *cobra.Command {
 				}
 			}
 
-			if flags.vmImageIncus != "" {
-				if err := index.ImportImage(cmd.Context(), lxc.VirtualMachine, flags.vmImageIncus, flags.alias, true, false); err != nil {
+			if flags.virtualMachineImage != "" {
+				if err := index.ImportImage(cmd.Context(), lxc.VirtualMachine, flags.virtualMachineImage, flags.alias, true, true); err != nil {
 					return fmt.Errorf("failed to import Incus VM image: %w", err)
-				}
-			}
-
-			if flags.vmImageLXD != "" {
-				if err := index.ImportImage(cmd.Context(), lxc.VirtualMachine, flags.vmImageLXD, flags.alias, false, true); err != nil {
-					return fmt.Errorf("failed to import LXD VM image: %w", err)
 				}
 			}
 
@@ -58,10 +51,8 @@ func newImportReleaseCmd() *cobra.Command {
 		"alias to add to the images, e.g. 'kubeadm/v1.33.0,kubeadm/v1.33.0/ubuntu'")
 	cmd.Flags().StringVar(&flags.containerImage, "container", "",
 		"Path to kubeadm image for containers")
-	cmd.Flags().StringVar(&flags.vmImageIncus, "vm-incus", "",
-		"Path to kubeadm image for Incus virtual machines")
-	cmd.Flags().StringVar(&flags.vmImageLXD, "vm-lxd", "",
-		"Path to kubeadm image for LXD virtual machines")
+	cmd.Flags().StringVar(&flags.virtualMachineImage, "vm", "",
+		"Path to kubeadm image for virtual machines")
 
 	_ = cmd.MarkPersistentFlagRequired("version")
 

--- a/internal/static/embed/cleanup-instance.sh
+++ b/internal/static/embed/cleanup-instance.sh
@@ -13,6 +13,27 @@ if cat /etc/os-release | grep ID=ubuntu -q; then
   apt-get purge -y ubuntu-pro-client language-pack-en-base
 fi
 
+# NOTE(neoaggelos): Ensure VM images built with Incus load the LXD agent at runtime
+if [ -f /lib/systemd/system/incus-agent.service ]; then
+  if cat /etc/os-release | grep ID=ubuntu -q; then
+    apt install lxd-agent-loader -y --no-install-recommends
+  else
+    # For other distributions, download deb package and install manually
+    curl -L https://launchpad.net/ubuntu/+archive/primary/+files/lxd-agent-loader_0.7ubuntu0.1_all.deb -o lxd-agent.deb
+    if ! sha256sum lxd-agent.deb | grep -q ce2aa5b188fb286f9c8eae05ad424bb10a161d260f64a57163f0f66f03880752; then
+      echo "*****DANGER!!!!!*****"
+      echo "lxd-agent.deb file sha256sum mismatch, refusing to proceed"
+      echo "*********************"
+      exit 1
+    fi
+
+    apt install ./lxd-agent.deb -y && rm lxd-agent.deb
+  fi
+
+  # limit lxd-agent.service so that it only starts on Canonical LXD
+  echo 'SYMLINK=="virtio-ports/com.canonical.lxd", TAG+="systemd", ENV{SYSTEMD_WANTS}+="lxd-agent.service"' | tee /lib/udev/rules.d/99-lxd-agent.rules
+fi
+
 apt-get autoremove -y && apt-get clean && apt-get autoclean
 rm -rf \
   /home/ubuntu/.bash_history \


### PR DESCRIPTION
### Summary

Make sure the VM images built with `image-builder` can be used with both Incus and Canonical LXD.

### Changes

- Install `lxd-agent-loader` on the VM. When the image is used on LXD, this will initialize the lxd-agent service
- Patch the lxd-agent default udev rules, so that Incus VMs do not have a race condition between lxd-agent and incus-agent

### Notes

This means we no longer need to build separate VM images for Incus and Canonical LXD (same as for the LXC container images).