### PR TITLE
add contents: write permission to build images job

### DIFF
--- a/.github/workflows/build-kubeadm-images.yml
+++ b/.github/workflows/build-kubeadm-images.yml
@@ -8,11 +8,10 @@ on:
         description: Kubernetes version, e.g. "v1.33.0"
         type: string
 
-permissions:
-  contents: write
-
 jobs:
   build:
+    permissions:
+      contents: write   # for release
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build-kubeadm-images.yml
+++ b/.github/workflows/build-kubeadm-images.yml
@@ -8,6 +8,9 @@ on:
         description: Kubernetes version, e.g. "v1.33.0"
         type: string
 
+permissions:
+  contents: write
+
 jobs:
   build:
     strategy:


### PR DESCRIPTION
### Summary

Otherwise job fails with error

```
Run softprops/action-gh-release@v2
Found release Kubeadm images (with id=248797837)
⚠️ Unexpected error fetching GitHub release for tag refs/heads/main: HttpError: Resource not accessible by integration - https://docs.github.com/rest/releases/releases#update-a-release
Error: Resource not accessible by integration - https://docs.github.com/rest/releases/releases#update-a-release
```