### PR TITLE
chore: allow creating lxc clients over unix sockets

### DIFF
--- a/internal/lxc/client.go
+++ b/internal/lxc/client.go
@@ -3,6 +3,7 @@ package lxc
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	incus "github.com/lxc/incus/v6/client"
 	"github.com/lxc/incus/v6/shared/api"
@@ -28,30 +29,42 @@ func (c *Client) WithProgressHandler(f func(api.Operation)) {
 func New(ctx context.Context, config Configuration, options ...Option) (*Client, error) {
 	log := log.FromContext(ctx).WithValues("lxc.server", config.ServerURL)
 
+	var (
+		client incus.InstanceServer
+		err    error
+	)
 	switch {
-	case config.InsecureSkipVerify:
-		log = log.WithValues("lxc.insecure-skip-verify", true)
-		config.ServerCrt = ""
-	case config.ServerCrt == "":
-		log = log.WithValues("lxc.server-crt", "<unset>")
-	case config.ServerCrt != "":
-		if fingerprint, err := tls.CertFingerprintStr(config.ServerCrt); err == nil && len(fingerprint) >= 12 {
-			log = log.WithValues("lxc.server-crt", fingerprint[:12])
+	case strings.HasPrefix(config.ServerURL, "https://"):
+		switch {
+		case config.InsecureSkipVerify:
+			log = log.WithValues("lxc.insecure-skip-verify", true)
+			config.ServerCrt = ""
+		case config.ServerCrt == "":
+			log = log.WithValues("lxc.server-crt", "<unset>")
+		case config.ServerCrt != "":
+			if fingerprint, err := tls.CertFingerprintStr(config.ServerCrt); err == nil && len(fingerprint) >= 12 {
+				log = log.WithValues("lxc.server-crt", fingerprint[:12])
+			}
 		}
-	}
 
-	if fingerprint, err := tls.CertFingerprintStr(config.ClientCrt); err == nil && len(fingerprint) >= 12 {
-		log = log.WithValues("lxc.client-crt", fingerprint[:12])
-	}
+		if fingerprint, err := tls.CertFingerprintStr(config.ClientCrt); err == nil && len(fingerprint) >= 12 {
+			log = log.WithValues("lxc.client-crt", fingerprint[:12])
+		}
 
-	client, err := incus.ConnectIncusWithContext(ctx, config.ServerURL, &incus.ConnectionArgs{
-		TLSServerCert:      config.ServerCrt,
-		TLSClientCert:      config.ClientCrt,
-		TLSClientKey:       config.ClientKey,
-		InsecureSkipVerify: config.InsecureSkipVerify,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("failed to initialize client: %w", err)
+		if client, err = incus.ConnectIncusWithContext(ctx, config.ServerURL, &incus.ConnectionArgs{
+			TLSServerCert:      config.ServerCrt,
+			TLSClientCert:      config.ClientCrt,
+			TLSClientKey:       config.ClientKey,
+			InsecureSkipVerify: config.InsecureSkipVerify,
+		}); err != nil {
+			return nil, fmt.Errorf("failed to initialize client over HTTPS: %w", err)
+		}
+	case strings.HasPrefix(config.ServerURL, "unix://"):
+		if client, err = incus.ConnectIncusUnixWithContext(ctx, strings.TrimPrefix(config.ServerURL, "unix://"), nil); err != nil {
+			return nil, fmt.Errorf("failed to initialize client over unix socket: %w", err)
+		}
+	default:
+		return nil, fmt.Errorf("server %q is not unix:// or https://", config.ServerURL)
 	}
 
 	if config.Project != "" {


### PR DESCRIPTION
### Summary

Allow creating lxc clients over UNIX sockets, if requested. This is preliminary work for `kini`