### PR TITLE
chore: include architecture in imported image path

### DIFF
--- a/cmd/exp/simplestreams/internal/index/import_container.go
+++ b/cmd/exp/simplestreams/internal/index/import_container.go
@@ -70,7 +70,7 @@ func (i *Index) importContainerUnifiedTarball(ctx context.Context, imagePath str
 
 	productName := fmt.Sprintf("%s:%s:%s:%s", metadata.Properties["os"], metadata.Properties["release"], metadata.Properties["variant"], metadata.Properties["architecture"])
 	versionName := time.Unix(metadata.CreationDate, 0).Format("200601021504")
-	target := filepath.Join("images", metadata.Properties["os"], metadata.Properties["release"], fmt.Sprintf("%s.incus_combined.tar.gz", info.Sha256))
+	target := filepath.Join("images", metadata.Properties["os"], metadata.Properties["release"], metadata.Properties["architecture"], fmt.Sprintf("%s.incus_combined.tar.gz", info.Sha256))
 
 	log.FromContext(ctx).Info("Adding product version item", "product", productName, "version", versionName, "info", info)
 

--- a/cmd/exp/simplestreams/internal/index/import_virtual_machine.go
+++ b/cmd/exp/simplestreams/internal/index/import_virtual_machine.go
@@ -115,8 +115,8 @@ func (i *Index) importVirtualMachineUnifiedTarball(ctx context.Context, imagePat
 
 	productName := fmt.Sprintf("%s:%s:%s:%s", metadata.Properties["os"], metadata.Properties["release"], metadata.Properties["variant"], metadata.Properties["architecture"])
 	versionName := time.Unix(metadata.CreationDate, 0).Format("200601021504")
-	metadataTarget := filepath.Join("images", metadata.Properties["os"], metadata.Properties["release"], fmt.Sprintf("%s.incus.tar.xz", info.MetaSha256))
-	rootfsTarget := filepath.Join("images", metadata.Properties["os"], metadata.Properties["release"], fmt.Sprintf("%s.disk-kvm.img", info.MetaSha256))
+	metadataTarget := filepath.Join("images", metadata.Properties["os"], metadata.Properties["release"], metadata.Properties["architecture"], fmt.Sprintf("%s.incus.tar.xz", info.MetaSha256))
+	rootfsTarget := filepath.Join("images", metadata.Properties["os"], metadata.Properties["release"], metadata.Properties["architecture"], fmt.Sprintf("%s.disk-kvm.img", info.MetaSha256))
 
 	if err := os.MkdirAll(filepath.Join(i.rootDir, filepath.Dir(rootfsTarget)), 0755); err != nil {
 		return fmt.Errorf("failed to create images directory: %w", err)


### PR DESCRIPTION
### Summary

When importing images into a simplestreams index, path is now `kubeadm/$version/$arch/$image` instead of `kubeadm/$version/$image`. This will be followed for new images, and does not affect existing ones.

