### PR TITLE
manager: allow mounting unix socket into manager pod

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,6 +183,9 @@ release: manifests generate kustomize ## Generate a consolidated YAML with CRDs 
 	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
 	$(KUSTOMIZE) build config/default > dist/infrastructure-components.yaml
 
+	## NOTE(neoaggelos): see relevant note in unix_socket_patch.yaml
+	sed -i 's,volumes: \[\],volumes: $${CAPN_VOLUMES:=[]},' dist/infrastructure-components.yaml
+
 .PHONY: dist
 dist: release ## Generate release assets.
 	cp templates/clusterclass*.yaml dist/

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -35,6 +35,9 @@ resources:
 
 # Uncomment the patches line if you enable Metrics, and/or are using webhooks and cert-manager
 patches:
+- path: unix_socket_patch.yaml
+  target:
+    kind: Deployment
 # [METRICS] The following patch will enable the metrics endpoint using HTTPS and the port :8443.
 # More info: https://book.kubebuilder.io/reference/metrics
 - path: manager_metrics_patch.yaml

--- a/config/default/unix_socket_patch.yaml
+++ b/config/default/unix_socket_patch.yaml
@@ -1,0 +1,19 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: controller-manager
+  namespace: system
+spec:
+  template:
+    spec:
+      containers:
+      - name: manager
+        volumeMounts: ${CAPN_VOLUME_MOUNTS:=[]}
+      securityContext:
+        runAsNonRoot: ${CAPN_RUN_AS_NON_ROOT:=true}
+        runAsUser: ${CAPN_RUN_AS_USER:= }
+
+      # NOTE(neoaggelos): we cannot set "volumes: ${CAPN_VOLUMES:=[]}", as that is
+      # is illegal in kustomize and results in error. instead, we manually 'sed -i'
+      # the desired value afterwards.
+      volumes: []

--- a/test/e2e/data/config.yaml
+++ b/test/e2e/data/config.yaml
@@ -77,6 +77,9 @@ providers:
       new: "imagePullPolicy: IfNotPresent"
     - old: "--v=2"
       new: "--v=4"
+    ## NOTE(neoaggelos): see relevant note in unix_socket_patch.yaml
+    - old: "volumes: \\[\\]"
+      new: "volumes: ${CAPN_VOLUMES:=[]}"
 
 # default variables for the e2e test; those values could be overridden via env variables, thus
 # allowing the same e2e config file to be re-used in different prow jobs e.g. each one with a K8s version permutation


### PR DESCRIPTION
### Summary

prerequisite work for kini

Update capn-controller-manager to allow mounting a local unix socket. This also requires adjustments to the security context to run as root.

```
export CAPN_VOLUMES='[{name: unix-socket, hostPath: {path: /var/lib/incus/unix.socket}}]'
export CAPN_VOLUME_MOUNTS='[{name: unix-socket, mountPath: /var/lib/incus/unix.socket}]'
export CAPN_RUN_AS_USER=0
export CAPN_RUN_AS_NON_ROOT=false
```

### Security notes

Note that this is an opt-in configuration, and using this simplifies infrastructure credentials (no need to bind on HTTPS and generate client certificates, but requires running the capn-controller-manager as root.

As such, this is disabled by default.

