### PR TITLE
feat: Add support for custom HAProxy config template

### DIFF
--- a/api/v1alpha2/lxccluster_types.go
+++ b/api/v1alpha2/lxccluster_types.go
@@ -130,11 +130,6 @@ type LXCClusterLoadBalancer struct {
 	//
 	// +optional
 	External *LXCLoadBalancerExternal `json:"external,omitempty"`
-
-	// CustomHAProxyConfigTemplate allows you to replace the default HAProxy config file content.
-	// Please use it with caution, as there are no checks to ensure the validity of the configuration.
-	// +optional
-	CustomHAProxyConfigTemplate string `json:"customHAProxyConfigTemplate,omitempty"`
 }
 
 type LXCLoadBalancerInstance struct {
@@ -142,6 +137,11 @@ type LXCLoadBalancerInstance struct {
 	//
 	// +optional
 	InstanceSpec LXCLoadBalancerMachineSpec `json:"instanceSpec,omitempty"`
+
+	// CustomHAProxyConfigTemplate allows you to replace the default HAProxy config file content.
+	// Please use it with caution, as there are no checks to ensure the validity of the configuration.
+	// +optional
+	CustomHAProxyConfigTemplate string `json:"customHAProxyConfigTemplate,omitempty"`
 }
 
 type LXCLoadBalancerOVN struct {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclusters.yaml
@@ -80,11 +80,6 @@ spec:
                 maxProperties: 1
                 minProperties: 1
                 properties:
-                  customHAProxyConfigTemplate:
-                    description: |-
-                      CustomHAProxyConfigTemplate allows you to replace the default HAProxy config file content.
-                      Please use it with caution, as there are no checks to ensure the validity of the configuration.
-                    type: string
                   external:
                     description: |-
                       External will not create a load balancer. It must be used alongside something like kube-vip, otherwise the cluster will fail to provision.
@@ -133,6 +128,11 @@ spec:
 
                       The load balancer container is a single point of failure to access the workload cluster control plane. Therefore, it should only be used for development or evaluation clusters.
                     properties:
+                      customHAProxyConfigTemplate:
+                        description: |-
+                          CustomHAProxyConfigTemplate allows you to replace the default HAProxy config file content.
+                          Please use it with caution, as there are no checks to ensure the validity of the configuration.
+                        type: string
                       instanceSpec:
                         description: InstanceSpec can be used to adjust the load balancer
                           instance configuration.
@@ -226,6 +226,11 @@ spec:
 
                       Requires server extensions: `instance_oci`
                     properties:
+                      customHAProxyConfigTemplate:
+                        description: |-
+                          CustomHAProxyConfigTemplate allows you to replace the default HAProxy config file content.
+                          Please use it with caution, as there are no checks to ensure the validity of the configuration.
+                        type: string
                       instanceSpec:
                         description: InstanceSpec can be used to adjust the load balancer
                           instance configuration.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclustertemplates.yaml
@@ -100,11 +100,6 @@ spec:
                         maxProperties: 1
                         minProperties: 1
                         properties:
-                          customHAProxyConfigTemplate:
-                            description: |-
-                              CustomHAProxyConfigTemplate allows you to replace the default HAProxy config file content.
-                              Please use it with caution, as there are no checks to ensure the validity of the configuration.
-                            type: string
                           external:
                             description: |-
                               External will not create a load balancer. It must be used alongside something like kube-vip, otherwise the cluster will fail to provision.
@@ -153,6 +148,11 @@ spec:
 
                               The load balancer container is a single point of failure to access the workload cluster control plane. Therefore, it should only be used for development or evaluation clusters.
                             properties:
+                              customHAProxyConfigTemplate:
+                                description: |-
+                                  CustomHAProxyConfigTemplate allows you to replace the default HAProxy config file content.
+                                  Please use it with caution, as there are no checks to ensure the validity of the configuration.
+                                type: string
                               instanceSpec:
                                 description: InstanceSpec can be used to adjust the
                                   load balancer instance configuration.
@@ -247,6 +247,11 @@ spec:
 
                               Requires server extensions: `instance_oci`
                             properties:
+                              customHAProxyConfigTemplate:
+                                description: |-
+                                  CustomHAProxyConfigTemplate allows you to replace the default HAProxy config file content.
+                                  Please use it with caution, as there are no checks to ensure the validity of the configuration.
+                                type: string
                               instanceSpec:
                                 description: InstanceSpec can be used to adjust the
                                   load balancer instance configuration.

--- a/internal/loadbalancer/manager.go
+++ b/internal/loadbalancer/manager.go
@@ -37,7 +37,7 @@ func ManagerForCluster(cluster *clusterv1.Cluster, lxcCluster *infrav1.LXCCluste
 
 			name:                        lxcCluster.GetLoadBalancerInstanceName(),
 			spec:                        lxcCluster.Spec.LoadBalancer.LXC.InstanceSpec,
-			customHAProxyConfigTemplate: lxcCluster.Spec.LoadBalancer.CustomHAProxyConfigTemplate,
+			customHAProxyConfigTemplate: lxcCluster.Spec.LoadBalancer.LXC.CustomHAProxyConfigTemplate,
 		}
 	case lxcCluster.Spec.LoadBalancer.OCI != nil:
 		return &managerOCI{
@@ -47,7 +47,7 @@ func ManagerForCluster(cluster *clusterv1.Cluster, lxcCluster *infrav1.LXCCluste
 
 			name:                        lxcCluster.GetLoadBalancerInstanceName(),
 			spec:                        lxcCluster.Spec.LoadBalancer.OCI.InstanceSpec,
-			customHAProxyConfigTemplate: lxcCluster.Spec.LoadBalancer.CustomHAProxyConfigTemplate,
+			customHAProxyConfigTemplate: lxcCluster.Spec.LoadBalancer.OCI.CustomHAProxyConfigTemplate,
 		}
 	case lxcCluster.Spec.LoadBalancer.OVN != nil:
 		return &managerOVN{

--- a/internal/loadbalancer/manager_lxc.go
+++ b/internal/loadbalancer/manager_lxc.go
@@ -79,16 +79,15 @@ func (l *managerLXC) Reconfigure(ctx context.Context) error {
 		return fmt.Errorf("failed to build load balancer configuration: %w", err)
 	}
 
-	var haproxyCfg []byte
+	haproxyTemplate := DefaultHaproxyTemplate
 	if l.customHAProxyConfigTemplate != "" {
 		log.FromContext(ctx).V(1).Info("Using custom HAProxy configuration template")
-		haproxyCfg = []byte(l.customHAProxyConfigTemplate)
-	} else {
-		log.FromContext(ctx).V(1).Info("Using default HAProxy configuration template")
-		haproxyCfg, err = renderHaproxyConfiguration(config, DefaultHaproxyTemplate)
-		if err != nil {
-			return fmt.Errorf("failed to render load balancer config: %w", err)
-		}
+		haproxyTemplate = l.customHAProxyConfigTemplate
+	}
+
+	haproxyCfg, err := renderHaproxyConfiguration(config, haproxyTemplate)
+	if err != nil {
+		return fmt.Errorf("failed to render load balancer config: %w", err)
 	}
 
 	log.FromContext(ctx).V(1).WithValues("path", "/etc/haproxy/haproxy.cfg", "servers", config.BackendServers).Info("Write haproxy config")

--- a/internal/loadbalancer/manager_oci.go
+++ b/internal/loadbalancer/manager_oci.go
@@ -84,16 +84,15 @@ func (l *managerOCI) Reconfigure(ctx context.Context) error {
 		return fmt.Errorf("failed to build load balancer configuration: %w", err)
 	}
 
-	var haproxyCfg []byte
+	haproxyCfgTemplate := DefaultHaproxyTemplate
 	if l.customHAProxyConfigTemplate != "" {
 		log.FromContext(ctx).V(1).Info("Using custom HAProxy configuration template")
-		haproxyCfg = []byte(l.customHAProxyConfigTemplate)
-	} else {
-		log.FromContext(ctx).V(1).Info("Using default HAProxy configuration template")
-		haproxyCfg, err = renderHaproxyConfiguration(config, DefaultHaproxyTemplate)
-		if err != nil {
-			return fmt.Errorf("failed to render load balancer config: %w", err)
-		}
+		haproxyCfgTemplate = l.customHAProxyConfigTemplate
+	}
+
+	haproxyCfg, err := renderHaproxyConfiguration(config, haproxyCfgTemplate)
+	if err != nil {
+		return fmt.Errorf("failed to render load balancer config: %w", err)
 	}
 
 	log.FromContext(ctx).V(1).WithValues("path", "/usr/local/etc/haproxy/haproxy.cfg", "servers", config.BackendServers).Info("Write haproxy config")


### PR DESCRIPTION
<!--
  Thank you for making cluster-api-provider-incus better. Please fill the template below
  with more details.
-->

#### Summary
<!--
   Please explain the changes made in this pull request in a few short sentences.

   Link to any related issues and/or comments, e.g.

   Closes #issue-number
   References #issue-number
-->
This PR adds support for a custom HA proxy config template through the LXCCluster object.
Inspired by CAPD: https://github.com/kubernetes-sigs/cluster-api/blob/08b15d92faf7cede17123a4bef0d281815419dde/test/infrastructure/docker/api/v1beta1/dockercluster_types.go#L67

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->
* Add `CustomHAProxyConfigTemplateRef` to the `LXCClusterLoadBalancer`
* Read the custom template using the ref, and if found, overwrite the default template
