### PR TITLE
Fix ClusterClass variable definitions for ClusterAPI v1.11 compatibility

### DIFF
--- a/templates/clusterclass-capn-default.yaml
+++ b/templates/clusterclass-capn-default.yaml
@@ -57,6 +57,7 @@ spec:
         example: lxc-secret
         description: Name of secret with infrastructure credentials
   - name: loadBalancer
+    required: true
     schema:
       openAPIV3Schema:
         type: object
@@ -129,6 +130,7 @@ spec:
         maxProperties: 1
         minProperties: 1
   - name: instance
+    required: true
     schema:
       openAPIV3Schema:
         type: object
@@ -167,6 +169,7 @@ spec:
             default: false
             description: Inject preKubeadmCommands that install Kubeadm on the instance. This is useful if using a plain Ubuntu image.
   - name: etcdImageTag
+    required: false
     schema:
       openAPIV3Schema:
         type: string
@@ -174,6 +177,7 @@ spec:
         example: 3.5.16-0
         description: etcdImageTag sets the tag for the etcd image.
   - name: coreDNSImageTag
+    required: false
     schema:
       openAPIV3Schema:
         type: string
@@ -181,6 +185,7 @@ spec:
         example: v1.11.3
         description: coreDNSImageTag sets the tag for the coreDNS image.
   - name: privileged
+    required: false
     schema:
       openAPIV3Schema:
         type: boolean


### PR DESCRIPTION
### Summary

Update clusterclass definition to be compatible with ClusterAPI v1.11

### Notes

Addresses the following error (when using ClusterAPI v1.11):

```
$ kubectl apply -f templates/clusterclass-capn-default.yaml
Warning: cluster.x-k8s.io/v1beta1 ClusterClass is deprecated; use cluster.x-k8s.io/v1beta2 ClusterClass
Warning: controlplane.cluster.x-k8s.io/v1beta1 KubeadmControlPlaneTemplate is deprecated; use controlplane.cluster.x-k8s.io/v1beta2 KubeadmControlPlaneTemplate
kubeadmcontrolplanetemplate.controlplane.cluster.x-k8s.io/capn-default-control-plane created
lxcclustertemplate.infrastructure.cluster.x-k8s.io/capn-default-lxc-cluster created
lxcmachinetemplate.infrastructure.cluster.x-k8s.io/capn-default-control-plane created
lxcmachinetemplate.infrastructure.cluster.x-k8s.io/capn-default-default-worker created
Warning: bootstrap.cluster.x-k8s.io/v1beta1 KubeadmConfigTemplate is deprecated; use bootstrap.cluster.x-k8s.io/v1beta2 KubeadmConfigTemplate
kubeadmconfigtemplate.bootstrap.cluster.x-k8s.io/capn-default-default-worker created
The ClusterClass "capn-default" is invalid: 
* spec.variables[1].required: Required value
* spec.variables[2].required: Required value
* spec.variables[3].required: Required value
* spec.variables[4].required: Required value
* spec.variables[5].required: Required value
```