### PR TITLE
prepare v0.8.0 release and update roadmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,14 @@ See [Quick Start](https://capn.linuxcontainers.org/tutorial/quick-start.html) to
 
 ## Project Roadmap
 
-### v0.8.0
+### v0.9.0
 
-Rough steps for version v0.8.0:
+Rough steps for version v0.9.0:
 
-- [ ] Add `kini` command line tool, re-using building blocks from [kind](https://kind.sigs.k8s.io).
-- [ ] Use `kini` for quick start guide and e2e tests.
+- [ ] Use `kini` for quick start guide.
 - [ ] Load balancer IPAM (CAPN automatically claims/releases load balancer IP addresses from the network).
+- [x] Add `kini` command line tool, re-using building blocks from [kind](https://kind.sigs.k8s.io).
+- [x] Use `kini` for e2e tests.
 - [x] Build images for v1.34.0, based on Ubuntu 24.04 and Debian 13.
 - [x] Private initial alpha testing.
 - [x] Cloud provider node patch to link Machines with workload cluster Nodes.

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -22,3 +22,6 @@ releaseSeries:
 - major: 0
   minor: 7
   contract: v1beta1
+- major: 0
+  minor: 8
+  contract: v1beta1


### PR DESCRIPTION
### Summary

Prepare for release v0.8.0, introducing `kini`.