### PR TITLE
Fix running conformance tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,7 @@ test-e2e: ginkgo kustomize kini ## Run e2e tests
 				$(E2E_ARGS)
 
 .PHONY: run-test-conformance
+run-test-conformance: TAG = e2e
 run-test-conformance: ginkgo kustomize ko-load-docker
 	env \
 		KUBETEST_CONFIGURATION="$(KUBETEST_CONFIGURATION)" \


### PR DESCRIPTION
### Summary

Properly load e2e image before running conformance tests. Example run is at https://github.com/neoaggelos/cluster-api-provider-incus/actions/runs/19018922609/job/54310916433

### Notes

This is a short-term fix to unblock the conformance tests for the v0.8 release. Eventually, the e2e spec will be updated to not rely on `docker` commands