### PR TITLE
Move to https://images.linuxcontainers.org/capn/ image server

### DIFF
--- a/api/v1alpha2/lxcmachine_types.go
+++ b/api/v1alpha2/lxcmachine_types.go
@@ -168,16 +168,16 @@ type LXCMachineImageSource struct {
 	//   - `ubuntu:VERSION` => `ubuntu/VERSION/cloud` from https://images.linuxcontainers.org
 	//   - `debian:VERSION` => `debian/VERSION/cloud` from https://images.linuxcontainers.org
 	//   - `images:IMAGE` => `IMAGE` from https://images.linuxcontainers.org
-	//   - `capi:IMAGE` => `IMAGE` from https://images.capn.open-cloud.xyz
-	//   - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz
+	//   - `capi:IMAGE` => `IMAGE` from https://images.linuxcontainers.org/capn/
+	//   - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz/capn/staging/
 	//
 	// For LXD:
 	//
 	//   - `ubuntu:VERSION` => `VERSION` from https://cloud-images.ubuntu.com/releases
 	//   - `debian:VERSION` => `debian/VERSION/cloud` from https://images.lxd.canonical.com
 	//   - `images:IMAGE` => `IMAGE` from https://images.lxd.canonical.com
-	//   - `capi:IMAGE` => `IMAGE` from https://images.capn.open-cloud.xyz
-	//   - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz
+	//   - `capi:IMAGE` => `IMAGE` from https://images.linuxcontainers.org/capn/
+	//   - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz/capn/staging/
 	//
 	// Any instances of `VERSION` in the image name will be replaced with the machine version.
 	// For example, to use debian based kubeadm images, you can set image name to "capi:kubeadm/VERSION/debian"

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclusters.yaml
@@ -169,16 +169,16 @@ spec:
                                     - `ubuntu:VERSION` => `ubuntu/VERSION/cloud` from https://images.linuxcontainers.org
                                     - `debian:VERSION` => `debian/VERSION/cloud` from https://images.linuxcontainers.org
                                     - `images:IMAGE` => `IMAGE` from https://images.linuxcontainers.org
-                                    - `capi:IMAGE` => `IMAGE` from https://images.capn.open-cloud.xyz
-                                    - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz
+                                    - `capi:IMAGE` => `IMAGE` from https://images.linuxcontainers.org/capn/
+                                    - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz/capn/staging/
 
                                   For LXD:
 
                                     - `ubuntu:VERSION` => `VERSION` from https://cloud-images.ubuntu.com/releases
                                     - `debian:VERSION` => `debian/VERSION/cloud` from https://images.lxd.canonical.com
                                     - `images:IMAGE` => `IMAGE` from https://images.lxd.canonical.com
-                                    - `capi:IMAGE` => `IMAGE` from https://images.capn.open-cloud.xyz
-                                    - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz
+                                    - `capi:IMAGE` => `IMAGE` from https://images.linuxcontainers.org/capn/
+                                    - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz/capn/staging/
 
                                   Any instances of `VERSION` in the image name will be replaced with the machine version.
                                   For example, to use debian based kubeadm images, you can set image name to "capi:kubeadm/VERSION/debian"
@@ -267,16 +267,16 @@ spec:
                                     - `ubuntu:VERSION` => `ubuntu/VERSION/cloud` from https://images.linuxcontainers.org
                                     - `debian:VERSION` => `debian/VERSION/cloud` from https://images.linuxcontainers.org
                                     - `images:IMAGE` => `IMAGE` from https://images.linuxcontainers.org
-                                    - `capi:IMAGE` => `IMAGE` from https://images.capn.open-cloud.xyz
-                                    - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz
+                                    - `capi:IMAGE` => `IMAGE` from https://images.linuxcontainers.org/capn/
+                                    - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz/capn/staging/
 
                                   For LXD:
 
                                     - `ubuntu:VERSION` => `VERSION` from https://cloud-images.ubuntu.com/releases
                                     - `debian:VERSION` => `debian/VERSION/cloud` from https://images.lxd.canonical.com
                                     - `images:IMAGE` => `IMAGE` from https://images.lxd.canonical.com
-                                    - `capi:IMAGE` => `IMAGE` from https://images.capn.open-cloud.xyz
-                                    - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz
+                                    - `capi:IMAGE` => `IMAGE` from https://images.linuxcontainers.org/capn/
+                                    - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz/capn/staging/
 
                                   Any instances of `VERSION` in the image name will be replaced with the machine version.
                                   For example, to use debian based kubeadm images, you can set image name to "capi:kubeadm/VERSION/debian"

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclustertemplates.yaml
@@ -189,16 +189,16 @@ spec:
                                             - `ubuntu:VERSION` => `ubuntu/VERSION/cloud` from https://images.linuxcontainers.org
                                             - `debian:VERSION` => `debian/VERSION/cloud` from https://images.linuxcontainers.org
                                             - `images:IMAGE` => `IMAGE` from https://images.linuxcontainers.org
-                                            - `capi:IMAGE` => `IMAGE` from https://images.capn.open-cloud.xyz
-                                            - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz
+                                            - `capi:IMAGE` => `IMAGE` from https://images.linuxcontainers.org/capn/
+                                            - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz/capn/staging/
 
                                           For LXD:
 
                                             - `ubuntu:VERSION` => `VERSION` from https://cloud-images.ubuntu.com/releases
                                             - `debian:VERSION` => `debian/VERSION/cloud` from https://images.lxd.canonical.com
                                             - `images:IMAGE` => `IMAGE` from https://images.lxd.canonical.com
-                                            - `capi:IMAGE` => `IMAGE` from https://images.capn.open-cloud.xyz
-                                            - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz
+                                            - `capi:IMAGE` => `IMAGE` from https://images.linuxcontainers.org/capn/
+                                            - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz/capn/staging/
 
                                           Any instances of `VERSION` in the image name will be replaced with the machine version.
                                           For example, to use debian based kubeadm images, you can set image name to "capi:kubeadm/VERSION/debian"
@@ -288,16 +288,16 @@ spec:
                                             - `ubuntu:VERSION` => `ubuntu/VERSION/cloud` from https://images.linuxcontainers.org
                                             - `debian:VERSION` => `debian/VERSION/cloud` from https://images.linuxcontainers.org
                                             - `images:IMAGE` => `IMAGE` from https://images.linuxcontainers.org
-                                            - `capi:IMAGE` => `IMAGE` from https://images.capn.open-cloud.xyz
-                                            - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz
+                                            - `capi:IMAGE` => `IMAGE` from https://images.linuxcontainers.org/capn/
+                                            - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz/capn/staging/
 
                                           For LXD:
 
                                             - `ubuntu:VERSION` => `VERSION` from https://cloud-images.ubuntu.com/releases
                                             - `debian:VERSION` => `debian/VERSION/cloud` from https://images.lxd.canonical.com
                                             - `images:IMAGE` => `IMAGE` from https://images.lxd.canonical.com
-                                            - `capi:IMAGE` => `IMAGE` from https://images.capn.open-cloud.xyz
-                                            - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz
+                                            - `capi:IMAGE` => `IMAGE` from https://images.linuxcontainers.org/capn/
+                                            - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz/capn/staging/
 
                                           Any instances of `VERSION` in the image name will be replaced with the machine version.
                                           For example, to use debian based kubeadm images, you can set image name to "capi:kubeadm/VERSION/debian"

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcmachines.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcmachines.yaml
@@ -129,16 +129,16 @@ spec:
                         - `ubuntu:VERSION` => `ubuntu/VERSION/cloud` from https://images.linuxcontainers.org
                         - `debian:VERSION` => `debian/VERSION/cloud` from https://images.linuxcontainers.org
                         - `images:IMAGE` => `IMAGE` from https://images.linuxcontainers.org
-                        - `capi:IMAGE` => `IMAGE` from https://images.capn.open-cloud.xyz
-                        - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz
+                        - `capi:IMAGE` => `IMAGE` from https://images.linuxcontainers.org/capn/
+                        - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz/capn/staging/
 
                       For LXD:
 
                         - `ubuntu:VERSION` => `VERSION` from https://cloud-images.ubuntu.com/releases
                         - `debian:VERSION` => `debian/VERSION/cloud` from https://images.lxd.canonical.com
                         - `images:IMAGE` => `IMAGE` from https://images.lxd.canonical.com
-                        - `capi:IMAGE` => `IMAGE` from https://images.capn.open-cloud.xyz
-                        - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz
+                        - `capi:IMAGE` => `IMAGE` from https://images.linuxcontainers.org/capn/
+                        - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz/capn/staging/
 
                       Any instances of `VERSION` in the image name will be replaced with the machine version.
                       For example, to use debian based kubeadm images, you can set image name to "capi:kubeadm/VERSION/debian"

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcmachinetemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcmachinetemplates.yaml
@@ -144,16 +144,16 @@ spec:
                                 - `ubuntu:VERSION` => `ubuntu/VERSION/cloud` from https://images.linuxcontainers.org
                                 - `debian:VERSION` => `debian/VERSION/cloud` from https://images.linuxcontainers.org
                                 - `images:IMAGE` => `IMAGE` from https://images.linuxcontainers.org
-                                - `capi:IMAGE` => `IMAGE` from https://images.capn.open-cloud.xyz
-                                - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz
+                                - `capi:IMAGE` => `IMAGE` from https://images.linuxcontainers.org/capn/
+                                - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz/capn/staging/
 
                               For LXD:
 
                                 - `ubuntu:VERSION` => `VERSION` from https://cloud-images.ubuntu.com/releases
                                 - `debian:VERSION` => `debian/VERSION/cloud` from https://images.lxd.canonical.com
                                 - `images:IMAGE` => `IMAGE` from https://images.lxd.canonical.com
-                                - `capi:IMAGE` => `IMAGE` from https://images.capn.open-cloud.xyz
-                                - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz
+                                - `capi:IMAGE` => `IMAGE` from https://images.linuxcontainers.org/capn/
+                                - `capi-stg:IMAGE` => `IMAGE` from https://images-stg.capn.open-cloud.xyz/capn/staging/
 
                               Any instances of `VERSION` in the image name will be replaced with the machine version.
                               For example, to use debian based kubeadm images, you can set image name to "capi:kubeadm/VERSION/debian"

--- a/docs/book/src/reference/api/v1alpha2/api.md
+++ b/docs/book/src/reference/api/v1alpha2/api.md
@@ -245,7 +245,7 @@ LXCLoadBalancerExternal
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCCluster">LXCCluster</a>,
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCCluster">LXCCluster</a>, 
 <a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCClusterTemplateResource">LXCClusterTemplateResource</a>)
 </p>
 <p>
@@ -1071,7 +1071,7 @@ LXCMachineStatus
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCLoadBalancerMachineSpec">LXCLoadBalancerMachineSpec</a>,
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCLoadBalancerMachineSpec">LXCLoadBalancerMachineSpec</a>, 
 <a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCMachineSpec">LXCMachineSpec</a>)
 </p>
 <p>
@@ -1101,16 +1101,16 @@ mitigate this issue, the following image names are recognized:</p>
 <li><code>ubuntu:VERSION</code> =&gt; <code>ubuntu/VERSION/cloud</code> from <a href="https://images.linuxcontainers.org">https://images.linuxcontainers.org</a></li>
 <li><code>debian:VERSION</code> =&gt; <code>debian/VERSION/cloud</code> from <a href="https://images.linuxcontainers.org">https://images.linuxcontainers.org</a></li>
 <li><code>images:IMAGE</code> =&gt; <code>IMAGE</code> from <a href="https://images.linuxcontainers.org">https://images.linuxcontainers.org</a></li>
-<li><code>capi:IMAGE</code> =&gt; <code>IMAGE</code> from <a href="https://images.capn.open-cloud.xyz">https://images.capn.open-cloud.xyz</a></li>
-<li><code>capi-stg:IMAGE</code> =&gt; <code>IMAGE</code> from <a href="https://images-stg.capn.open-cloud.xyz">https://images-stg.capn.open-cloud.xyz</a></li>
+<li><code>capi:IMAGE</code> =&gt; <code>IMAGE</code> from <a href="https://images.linuxcontainers.org/capn/">https://images.linuxcontainers.org/capn/</a></li>
+<li><code>capi-stg:IMAGE</code> =&gt; <code>IMAGE</code> from <a href="https://images-stg.capn.open-cloud.xyz/capn/staging/">https://images-stg.capn.open-cloud.xyz/capn/staging/</a></li>
 </ul>
 <p>For LXD:</p>
 <ul>
 <li><code>ubuntu:VERSION</code> =&gt; <code>VERSION</code> from <a href="https://cloud-images.ubuntu.com/releases">https://cloud-images.ubuntu.com/releases</a></li>
 <li><code>debian:VERSION</code> =&gt; <code>debian/VERSION/cloud</code> from <a href="https://images.lxd.canonical.com">https://images.lxd.canonical.com</a></li>
 <li><code>images:IMAGE</code> =&gt; <code>IMAGE</code> from <a href="https://images.lxd.canonical.com">https://images.lxd.canonical.com</a></li>
-<li><code>capi:IMAGE</code> =&gt; <code>IMAGE</code> from <a href="https://images.capn.open-cloud.xyz">https://images.capn.open-cloud.xyz</a></li>
-<li><code>capi-stg:IMAGE</code> =&gt; <code>IMAGE</code> from <a href="https://images-stg.capn.open-cloud.xyz">https://images-stg.capn.open-cloud.xyz</a></li>
+<li><code>capi:IMAGE</code> =&gt; <code>IMAGE</code> from <a href="https://images.linuxcontainers.org/capn/">https://images.linuxcontainers.org/capn/</a></li>
+<li><code>capi-stg:IMAGE</code> =&gt; <code>IMAGE</code> from <a href="https://images-stg.capn.open-cloud.xyz/capn/staging/">https://images-stg.capn.open-cloud.xyz/capn/staging/</a></li>
 </ul>
 <p>Any instances of <code>VERSION</code> in the image name will be replaced with the machine version.
 For example, to use debian based kubeadm images, you can set image name to &ldquo;capi:kubeadm/VERSION/debian&rdquo;</p>
@@ -1158,7 +1158,7 @@ string
 </h3>
 <p>
 (<em>Appears on:</em>
-<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCMachine">LXCMachine</a>,
+<a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCMachine">LXCMachine</a>, 
 <a href="#infrastructure.cluster.x-k8s.io/v1alpha2.LXCMachineTemplateResource">LXCMachineTemplateResource</a>)
 </p>
 <p>

--- a/docs/book/src/reference/default-simplestreams-server.md
+++ b/docs/book/src/reference/default-simplestreams-server.md
@@ -1,14 +1,12 @@
 # Default Simplestreams Server
 
-The `cluster-api-provider-incus` project runs a simplestreams server with pre-built kubeadm images for specific Kubernetes versions.
+The `cluster-api-provider-incus` project offers pre-built kubeadm images for specific Kubernetes versions.
 
-The default simplestreams server is available through an Amazon CloudFront distribution at [https://images.capn.open-cloud.xyz](https://images.capn.open-cloud.xyz).
+The default simplestreams server is available under [https://images.linuxcontainers.org/capn/](https://images.linuxcontainers.org/capn/streams/v1/index.json).
 
-Running infrastructure costs are kindly subsidized by the [National Technical University Of Athens].
-
-> **WARNING: In 2025-12-19, the default simplestreams server has migrated to a new location.**
+> **WARNING: In 2025-12-31, the default simplestreams server has migrated to a new location. If using version `v0.8.2` or older, you are kindly requested to update to `v0.8.3` or newer.**
 >
-> **The new URL is at [https://images.capn.open-cloud.xyz](https://images.capn.open-cloud.xyz).**
+> **The new URL is at [https://images.linuxcontainers.org/capn/](https://images.linuxcontainers.org/capn/streams/v1/index.json).**
 >
 > **For more details, refer to [https://github.com/lxc/cluster-api-provider-incus/issues/180](https://github.com/lxc/cluster-api-provider-incus/issues/180)**
 
@@ -52,7 +50,7 @@ Note that the table above might be out of date. See [streams/v1/index.json] and 
 Configure the `capi` remote:
 
 ```bash
-incus remote add capi https://images.capn.open-cloud.xyz --protocol=simplestreams
+incus remote add capi https://images.linuxcontainers.org/capn/ --protocol=simplestreams
 ```
 
 List available images (with filters):
@@ -86,7 +84,7 @@ Example output:
 Configure the `capi` remote:
 
 ```bash
-lxc remote add capi https://images.capn.open-cloud.xyz --protocol=simplestreams
+lxc remote add capi https://images.linuxcontainers.org/capn/ --protocol=simplestreams
 ```
 
 List available images (with filters):
@@ -94,14 +92,14 @@ List available images (with filters):
 ```bash
 lxc image list capi:                                  # list all images
 lxc image list capi: type=virtual-machine             # list kvm images
-lxc image list capi: release=v1.33.0                  # list v1.33.0 images
+lxc image list capi: release=v1.35.0                  # list v1.35.0 images
 lxc image list capi: arch=amd64                       # list amd64 images
 ```
 
 Example output:
 
 ```bash
-# lxc image list capi: release=v1.33.0
+# lxc image list capi: release=v1.35.0
 +--------------------------------+--------------+--------+--------------------------------------+--------------+-----------------+------------+-------------------------------+
 |             ALIAS              | FINGERPRINT  | PUBLIC |             DESCRIPTION              | ARCHITECTURE |      TYPE       |    SIZE    |          UPLOAD DATE          |
 +--------------------------------+--------------+--------+--------------------------------------+--------------+-----------------+------------+-------------------------------+
@@ -120,5 +118,5 @@ Example output:
 [National Technical University Of Athens]: https://ntua.gr/en
 [Incus]: https://linuxcontainers.org/incus/docs/main/
 [Canonical LXD]: https://canonical-lxd.readthedocs-hosted.com/en/
-[streams/v1/index.json]: https://images.capn.open-cloud.xyz/streams/v1/index.json
-[streams/v1/images.json]: https://images.capn.open-cloud.xyz/streams/v1/images.json
+[streams/v1/index.json]: https://images.linuxcontainers.org/capn//streams/v1/index.json
+[streams/v1/images.json]: https://images.linuxcontainers.org/capn//streams/v1/images.json

--- a/docs/book/src/reference/templates/default.md
+++ b/docs/book/src/reference/templates/default.md
@@ -99,8 +99,8 @@ Note that Incus and Canonical LXD use incompatible image servers. To help mitiga
 - `ubuntu:VERSION` => `ubuntu/VERSION/cloud` from [https://images.linuxcontainers.org](https://images.linuxcontainers.org)
 - `debian:VERSION` => `debian/VERSION/cloud` from [https://images.linuxcontainers.org](https://images.linuxcontainers.org)
 - `images:IMAGE` => `IMAGE` from [https://images.linuxcontainers.org](https://images.linuxcontainers.org)
-- `capi:IMAGE` => `IMAGE` from [https://images.capn.open-cloud.xyz](https://images.capn.open-cloud.xyz) ([default simplestreams server](../default-simplestreams-server.md))
-- `capi-stg:IMAGE` => `IMAGE` from [https://images-stg.capn.open-cloud.xyz](https://images-stg.capn.open-cloud.xyz) (staging simplestreams server)
+- `capi:IMAGE` => `IMAGE` from [https://images.linuxcontainers.org/capn/](https://images.linuxcontainers.org/capn/) ([default simplestreams server](../default-simplestreams-server.md))
+- `capi-stg:IMAGE` => `IMAGE` from [https://images.linuxcontainers.org/capn/staging/](https://images.linuxcontainers.org/capn/staging/) ([default simplestreams server](../default-simplestreams-server.md))
 
 {{#/tab }}
 {{#tab Canonical LXD }}
@@ -108,8 +108,8 @@ Note that Incus and Canonical LXD use incompatible image servers. To help mitiga
 - `ubuntu:VERSION` => `VERSION` from [https://cloud-images.ubuntu.com/releases](https://cloud-images.ubuntu.com/releases)
 - `debian:VERSION` => `debian/VERSION/cloud` from [https://images.lxd.canonical.com](https://images.lxd.canonical.com)
 - `images:IMAGE` => `IMAGE` from [https://images.lxd.canonical.com](https://images.lxd.canonical.com)
-- `capi:IMAGE` => `IMAGE` from [https://images.capn.open-cloud.xyz](https://images.capn.open-cloud.xyz) ([default simplestreams server](../default-simplestreams-server.md))
-- `capi-stg:IMAGE` => `IMAGE` from [https://images-stg.capn.open-cloud.xyz](https://images-stg.capn.open-cloud.xyz) (staging simplestreams server)
+- `capi:IMAGE` => `IMAGE` from [https://images.linuxcontainers.org/capn/](https://images.linuxcontainers.org/capn/) ([default simplestreams server](../default-simplestreams-server.md))
+- `capi-stg:IMAGE` => `IMAGE` from [https://images.linuxcontainers.org/capn/staging/](https://images.linuxcontainers.org/capn/staging/) ([default simplestreams server](../default-simplestreams-server.md))
 
 {{#/tab }}
 {{#/tabs }}

--- a/internal/lxc/consts.go
+++ b/internal/lxc/consts.go
@@ -4,10 +4,10 @@ import "time"
 
 const (
 	// DefaultSimplestreamsServer is the default simplestreams server for fetching images.
-	DefaultSimplestreamsServer = "https://images.capn.open-cloud.xyz"
+	DefaultSimplestreamsServer = "https://images.linuxcontainers.org/capn/"
 
 	// DefaultStagingSimplestreamsServer is the default staging simplestreams server for fetching images.
-	DefaultStagingSimplestreamsServer = "https://images-stg.capn.open-cloud.xyz"
+	DefaultStagingSimplestreamsServer = "https://images-stg.capn.open-cloud.xyz/capn/staging/"
 
 	// DefaultIncusSimplestreamsServer is the default simplestreams server for Incus.
 	DefaultIncusSimplestreamsServer = "https://images.linuxcontainers.org"

--- a/internal/lxc/images_parse_test.go
+++ b/internal/lxc/images_parse_test.go
@@ -42,8 +42,8 @@ func TestParseImage(t *testing.T) {
 		{server: "incus", image: "ubuntu:24.04", expectParse: true, expectImageSource: simplestreamsImage("https://images.linuxcontainers.org", "ubuntu/24.04/cloud")},
 		{server: "incus", image: "debian:12", expectParse: true, expectImageSource: simplestreamsImage("https://images.linuxcontainers.org", "debian/12/cloud")},
 		{server: "incus", image: "images:almalinux/9/cloud", expectParse: true, expectImageSource: simplestreamsImage("https://images.linuxcontainers.org", "almalinux/9/cloud")},
-		{server: "incus", image: "capi:kubeadm/v1.33.0", expectParse: true, expectImageSource: simplestreamsImage("https://images.capn.open-cloud.xyz", "kubeadm/v1.33.0")},
-		{server: "incus", image: "capi-stg:kubeadm/v1.33.0", expectParse: true, expectImageSource: simplestreamsImage("https://images-stg.capn.open-cloud.xyz", "kubeadm/v1.33.0")},
+		{server: "incus", image: "capi:kubeadm/v1.33.0", expectParse: true, expectImageSource: simplestreamsImage("https://images.linuxcontainers.org/capn/", "kubeadm/v1.33.0")},
+		{server: "incus", image: "capi-stg:kubeadm/v1.33.0", expectParse: true, expectImageSource: simplestreamsImage("https://images-stg.capn.open-cloud.xyz/capn/staging/", "kubeadm/v1.33.0")},
 		{server: "incus", image: "kind:v1.33.0", expectParse: true, expectImageSource: ociImage("https://docker.io", "kindest/node:v1.33.0")},
 		// verify lxd prefixes
 		{server: "lxd", image: "image-name"},
@@ -51,8 +51,8 @@ func TestParseImage(t *testing.T) {
 		{server: "lxd", image: "ubuntu:24.04", expectParse: true, expectImageSource: simplestreamsImage("https://cloud-images.ubuntu.com/releases/", "24.04")},
 		{server: "lxd", image: "debian:12", expectParse: true, expectImageSource: simplestreamsImage("https://images.lxd.canonical.com", "debian/12/cloud")},
 		{server: "lxd", image: "images:almalinux/9/cloud", expectParse: true, expectImageSource: simplestreamsImage("https://images.lxd.canonical.com", "almalinux/9/cloud")},
-		{server: "lxd", image: "capi:kubeadm/v1.33.0", expectParse: true, expectImageSource: simplestreamsImage("https://images.capn.open-cloud.xyz", "kubeadm/v1.33.0")},
-		{server: "lxd", image: "capi-stg:kubeadm/v1.33.0", expectParse: true, expectImageSource: simplestreamsImage("https://images-stg.capn.open-cloud.xyz", "kubeadm/v1.33.0")},
+		{server: "lxd", image: "capi:kubeadm/v1.33.0", expectParse: true, expectImageSource: simplestreamsImage("https://images.linuxcontainers.org/capn/", "kubeadm/v1.33.0")},
+		{server: "lxd", image: "capi-stg:kubeadm/v1.33.0", expectParse: true, expectImageSource: simplestreamsImage("https://images-stg.capn.open-cloud.xyz/capn/staging/", "kubeadm/v1.33.0")},
 		{server: "lxd", image: "kind:v1.33.0", expectParse: true, expectImageSource: ociImage("https://docker.io", "kindest/node:v1.33.0")},
 		// verify prefixes for unknown
 		{server: "unknown", image: "image-name"},

--- a/internal/lxc/images_sources.go
+++ b/internal/lxc/images_sources.go
@@ -59,7 +59,7 @@ func DefaultImage(image string) ImageFamily {
 }
 
 func CapnImage(image string) Image {
-	return Image{ // "capi:IMAGE" -> "IMAGE" from "https://images.capn.open-cloud.xyz"
+	return Image{ // "capi:IMAGE" -> "IMAGE" from "https://images.linuxcontainers.org/capn/"
 		Protocol: Simplestreams,
 		Server:   DefaultSimplestreamsServer,
 		Alias:    image,
@@ -67,7 +67,7 @@ func CapnImage(image string) Image {
 }
 
 func CapnStagingImage(image string) Image {
-	return Image{ // "capi-stg:IMAGE" -> "IMAGE" from "https://images-stg.capn.open-cloud.xyz"
+	return Image{ // "capi-stg:IMAGE" -> "IMAGE" from "https://images-stg.capn.open-cloud.xyz/capn/staging/"
 		Protocol: Simplestreams,
 		Server:   DefaultStagingSimplestreamsServer,
 		Alias:    image,

--- a/test/e2e/data/config.yaml
+++ b/test/e2e/data/config.yaml
@@ -4,7 +4,7 @@
 managementClusterName: capn-e2e
 
 images:
-# NOTE(neoaggelos): Ensure https://images.capn.open-cloud.xyz/streams/v1/index.json has kubeadm image for DefaultNodeImageVersion.
+# NOTE(neoaggelos): Ensure https://images.linuxcontainers.org/capn/streams/v1/index.json has kubeadm image for DefaultNodeImageVersion.
 # https://github.com/kubernetes-sigs/cluster-api/blob/v1.10.9/test/framework/bootstrap/kind_provider.go#L40
 - name: registry.k8s.io/cluster-api/cluster-api-controller:v1.10.9
   loadBehavior: tryLoad


### PR DESCRIPTION
### Summary

References #180 

Machinery is introduced in #187, update to use the new image server.