### PR TITLE
Add LXCCluster.spec.cloudProviderNodePatch field

### DIFF
--- a/api/v1alpha2/lxccluster_types.go
+++ b/api/v1alpha2/lxccluster_types.go
@@ -63,6 +63,20 @@ type LXCClusterSpec struct {
 	// +optional
 	SkipDefaultKubeadmProfile bool `json:"skipDefaultKubeadmProfile"`
 
+	// Patch nodes in the workload cluster to set `.spec.providerID`. This is
+	// usually the responsibility of a cloud controller manager, but this does
+	// not currently exist for Incus.
+	//
+	// The default cluster templates do not need this flag. Instead, they are
+	// passing an extra kubelet argument `provider-id: {{ v1.local_hostname }}`,
+	// which is templated by cloud-init when node is brought up.
+	//
+	// However, this might not be easily doable when using other ControlPlane
+	// and Bootstrap providers, e.g. Talos.
+	//
+	// +optional
+	CloudProviderNodePatch bool `json:"cloudProviderNodePatch"`
+
 	// TODO(neoaggelos): enable failure domains
 	// FailureDomains clusterv1.FailureDomains `json:"failureDomains,omitempty"`
 }

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -36,6 +36,7 @@ import (
 	cliflag "k8s.io/component-base/cli/flag"
 	"k8s.io/klog/v2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	"sigs.k8s.io/cluster-api/controllers/remote"
 	"sigs.k8s.io/cluster-api/util/flags"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -67,6 +68,8 @@ var (
 	syncPeriod                  time.Duration
 	restConfigQPS               float32
 	restConfigBurst             int
+	clusterCacheClientQPS       float32
+	clusterCacheClientBurst     int
 	webhookPort                 int
 	webhookCertDir              string
 	webhookCertName             string
@@ -75,7 +78,8 @@ var (
 	managerOptions              = flags.ManagerOptions{}
 
 	// CAPN specific flags.
-	concurrency int
+	concurrency             int
+	clusterCacheConcurrency int
 )
 
 func init() {
@@ -126,6 +130,9 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&concurrency, "concurrency", 10,
 		"The number of docker machines to process simultaneously")
 
+	fs.IntVar(&clusterCacheConcurrency, "clustercache-concurrency", 100,
+		"Number of clusters to process simultaneously")
+
 	fs.DurationVar(&syncPeriod, "sync-period", 10*time.Minute,
 		"The minimum interval at which watched resources are reconciled (e.g. 15m)")
 
@@ -135,6 +142,14 @@ func InitFlags(fs *pflag.FlagSet) {
 	fs.IntVar(&restConfigBurst, "kube-api-burst", 30,
 		"Maximum number of queries that should be allowed in one burst from the controller client to"+
 			" the Kubernetes API server.")
+
+	fs.Float32Var(&clusterCacheClientQPS, "clustercache-client-qps", 20,
+		"Maximum queries per second from the cluster cache clients to the Kubernetes API server of"+
+			" workload clusters.")
+
+	fs.IntVar(&clusterCacheClientBurst, "clustercache-client-burst", 30,
+		"Maximum number of queries that should be allowed in one burst from the cluster cache clients"+
+			" to the Kubernetes API server of workload clusters.")
 
 	fs.IntVar(&webhookPort, "webhook-port", 9443,
 		"Webhook Server port")
@@ -275,6 +290,41 @@ func setupChecks(mgr ctrl.Manager) {
 }
 
 func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
+	secretCachingClient, err := client.New(mgr.GetConfig(), client.Options{
+		HTTPClient: mgr.GetHTTPClient(),
+		Cache: &client.CacheOptions{
+			Reader: mgr.GetCache(),
+		},
+	})
+	if err != nil {
+		setupLog.Error(err, "Unable to create secret caching client")
+		os.Exit(1)
+	}
+
+	clusterCache, err := clustercache.SetupWithManager(ctx, mgr, clustercache.Options{
+		SecretClient: secretCachingClient,
+		Cache:        clustercache.CacheOptions{},
+		Client: clustercache.ClientOptions{
+			QPS:       clusterCacheClientQPS,
+			Burst:     clusterCacheClientBurst,
+			UserAgent: remote.DefaultClusterAPIUserAgent(controllerName),
+			Cache: clustercache.ClientCacheOptions{
+				DisableFor: []client.Object{
+					// Don't cache ConfigMaps & Secrets.
+					&corev1.ConfigMap{},
+					&corev1.Secret{},
+				},
+			},
+		},
+		WatchFilterValue: watchFilterValue,
+	}, ctrl_controller.Options{
+		MaxConcurrentReconciles: clusterCacheConcurrency,
+	})
+	if err != nil {
+		setupLog.Error(err, "Unable to create ClusterCache")
+		os.Exit(1)
+	}
+
 	if err := (&lxccluster.LXCClusterReconciler{
 		Client:           mgr.GetClient(),
 		WatchFilterValue: watchFilterValue,
@@ -286,6 +336,7 @@ func setupReconcilers(ctx context.Context, mgr ctrl.Manager) {
 	if err := (&lxcmachine.LXCMachineReconciler{
 		Client:           mgr.GetClient(),
 		WatchFilterValue: watchFilterValue,
+		ClusterCache:     clusterCache,
 	}).SetupWithManager(ctx, mgr, ctrl_controller.Options{
 		MaxConcurrentReconciles: concurrency,
 	}); err != nil {

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclusters.yaml
@@ -58,6 +58,19 @@ spec:
           spec:
             description: LXCClusterSpec defines the desired state of LXCCluster.
             properties:
+              cloudProviderNodePatch:
+                description: |-
+                  Patch nodes in the workload cluster to set `.spec.providerID`. This is
+                  usually the responsibility of a cloud controller manager, but this does
+                  not currently exist for Incus.
+
+                  The default cluster templates do not need this flag. Instead, they are
+                  passing an extra kubelet argument `provider-id: {{ v1.local_hostname }}`,
+                  which is templated by cloud-init when node is brought up.
+
+                  However, this might not be easily doable when using other ControlPlane
+                  and Bootstrap providers, e.g. Talos.
+                type: boolean
               controlPlaneEndpoint:
                 description: ControlPlaneEndpoint represents the endpoint to communicate
                   with the control plane.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclustertemplates.yaml
@@ -76,6 +76,19 @@ spec:
                   spec:
                     description: LXCClusterSpec defines the desired state of LXCCluster.
                     properties:
+                      cloudProviderNodePatch:
+                        description: |-
+                          Patch nodes in the workload cluster to set `.spec.providerID`. This is
+                          usually the responsibility of a cloud controller manager, but this does
+                          not currently exist for Incus.
+
+                          The default cluster templates do not need this flag. Instead, they are
+                          passing an extra kubelet argument `provider-id: {{ v1.local_hostname }}`,
+                          which is templated by cloud-init when node is brought up.
+
+                          However, this might not be easily doable when using other ControlPlane
+                          and Bootstrap providers, e.g. Talos.
+                        type: boolean
                       controlPlaneEndpoint:
                         description: ControlPlaneEndpoint represents the endpoint
                           to communicate with the control plane.

--- a/docs/book/src/reference/api/v1alpha2/api.md
+++ b/docs/book/src/reference/api/v1alpha2/api.md
@@ -121,6 +121,25 @@ LXCMachineTemplate objects.</p>
 <a href="https://capn.linuxcontainers.org/reference/profile/kubeadm.html">https://capn.linuxcontainers.org/reference/profile/kubeadm.html</a></p>
 </td>
 </tr>
+<tr>
+<td>
+<code>cloudProviderNodePatch</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Patch nodes in the workload cluster to set <code>.spec.providerID</code>. This is
+usually the responsibility of a cloud controller manager, but this does
+not currently exist for Incus.</p>
+<p>The default cluster templates do not need this flag. Instead, they are
+passing an extra kubelet argument <code>provider-id: {{ v1.local_hostname }}</code>,
+which is templated by cloud-init when node is brought up.</p>
+<p>However, this might not be easily doable when using other ControlPlane
+and Bootstrap providers, e.g. Talos.</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -326,6 +345,25 @@ profile manually and set the <code>.spec.template.spec.profiles</code> field of 
 LXCMachineTemplate objects.</p>
 <p>For more details on the default kubeadm profile that is applied, see
 <a href="https://capn.linuxcontainers.org/reference/profile/kubeadm.html">https://capn.linuxcontainers.org/reference/profile/kubeadm.html</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cloudProviderNodePatch</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Patch nodes in the workload cluster to set <code>.spec.providerID</code>. This is
+usually the responsibility of a cloud controller manager, but this does
+not currently exist for Incus.</p>
+<p>The default cluster templates do not need this flag. Instead, they are
+passing an extra kubelet argument <code>provider-id: {{ v1.local_hostname }}</code>,
+which is templated by cloud-init when node is brought up.</p>
+<p>However, this might not be easily doable when using other ControlPlane
+and Bootstrap providers, e.g. Talos.</p>
 </td>
 </tr>
 </tbody>
@@ -560,6 +598,25 @@ profile manually and set the <code>.spec.template.spec.profiles</code> field of 
 LXCMachineTemplate objects.</p>
 <p>For more details on the default kubeadm profile that is applied, see
 <a href="https://capn.linuxcontainers.org/reference/profile/kubeadm.html">https://capn.linuxcontainers.org/reference/profile/kubeadm.html</a></p>
+</td>
+</tr>
+<tr>
+<td>
+<code>cloudProviderNodePatch</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<em>(Optional)</em>
+<p>Patch nodes in the workload cluster to set <code>.spec.providerID</code>. This is
+usually the responsibility of a cloud controller manager, but this does
+not currently exist for Incus.</p>
+<p>The default cluster templates do not need this flag. Instead, they are
+passing an extra kubelet argument <code>provider-id: {{ v1.local_hostname }}</code>,
+which is templated by cloud-init when node is brought up.</p>
+<p>However, this might not be easily doable when using other ControlPlane
+and Bootstrap providers, e.g. Talos.</p>
 </td>
 </tr>
 </table>

--- a/internal/cloudprovider/node_patch.go
+++ b/internal/cloudprovider/node_patch.go
@@ -1,0 +1,79 @@
+package cloudprovider
+
+import (
+	"context"
+	"fmt"
+	"slices"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/util/patch"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+
+	infrav1 "github.com/lxc/cluster-api-provider-incus/api/v1alpha2"
+)
+
+var (
+	cloudProviderTaint = corev1.Taint{Key: "node.cloudprovider.kubernetes.io/uninitialized", Effect: corev1.TaintEffectNoSchedule}
+)
+
+func matchesCloudProviderTaint(taint corev1.Taint) bool {
+	return taint.MatchTaint(&cloudProviderTaint)
+}
+
+// PatchNode implements the responsibilities of the external cloud-provider for node objects in the workload cluster.
+// It is required because there is no external cloud-provider integration between Kubernetes and Incus.
+func PatchNode(ctx context.Context, remoteClient client.Client, lxcMachine *infrav1.LXCMachine) error {
+	expectedProviderID := lxcMachine.GetExpectedProviderID()
+	expectedRemoteNodeName := lxcMachine.GetInstanceName()
+
+	ctx = log.IntoContext(ctx, log.FromContext(ctx).WithValues("providerID", expectedProviderID, "nodeName", expectedRemoteNodeName))
+
+	remoteNode := &corev1.Node{}
+	if err := remoteClient.Get(ctx, types.NamespacedName{Name: lxcMachine.GetInstanceName()}, remoteNode); err != nil {
+		// NOTE(neoaggelos): we assume the node will appear with a name that matches the lxcMachine instance name.
+		// This might not be true in case of a non-Ubuntu OS (e.g. hostname vs fqdn), or in case a custom node name is set.
+		//
+		// However: this is what capd does, and the situations described above should be infrequent to not worry about right now.
+		return fmt.Errorf("failed to retrieve node with name %q from workload cluster: %w", lxcMachine.GetInstanceName(), err)
+	}
+
+	patchHelper, err := patch.NewHelper(remoteNode, remoteClient)
+	if err != nil {
+		return err
+	}
+
+	// 1. set providerID on the remote node
+	log.FromContext(ctx).Info("Setting providerID on remote node")
+	remoteNode.Spec.ProviderID = expectedProviderID
+
+	// slices.DeleteFunc() preserves the length of the original slice and zeroes out last elements. If length is different, it means node originally had the taint.
+	if taints := slices.DeleteFunc(remoteNode.Spec.Taints, matchesCloudProviderTaint); len(taints) != len(remoteNode.Spec.Taints) {
+		// 2. set addresses in the remoteNode `.status.addresses`
+		remoteNodeAddressSet := sets.New(remoteNode.Status.Addresses...)
+		for _, address := range lxcMachine.Status.Addresses {
+			// Only consider "InternalIP" addresses
+			if address.Type != clusterv1.MachineInternalIP {
+				continue
+			}
+			// Append address if not already set in the remoteNode
+			nodeAddress := corev1.NodeAddress{Type: corev1.NodeAddressType(address.Type), Address: address.Address}
+			if !remoteNodeAddressSet.Has(nodeAddress) {
+				log.FromContext(ctx).WithValues("address", nodeAddress).Info("Adding missing machine address to remote node")
+				remoteNode.Status.Addresses = append(remoteNode.Status.Addresses, nodeAddress)
+			}
+		}
+
+		// 3. remove cloud provider taint to initialize node
+		log.FromContext(ctx).WithValues("taint", cloudProviderTaint).Info("Removing cloud provider taint to initialize remote node")
+		remoteNode.Spec.Taints = taints
+	}
+
+	if err := patchHelper.Patch(ctx, remoteNode); err != nil {
+		return fmt.Errorf("failed to patch remote node: %w", err)
+	}
+	return nil
+}

--- a/internal/cloudprovider/node_patch_test.go
+++ b/internal/cloudprovider/node_patch_test.go
@@ -1,0 +1,84 @@
+package cloudprovider_test
+
+import (
+	"context"
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	infrav1 "github.com/lxc/cluster-api-provider-incus/api/v1alpha2"
+	"github.com/lxc/cluster-api-provider-incus/internal/cloudprovider"
+
+	. "github.com/onsi/gomega"
+)
+
+func TestPatchNode(t *testing.T) {
+	t.Run("SetProviderID", func(t *testing.T) {
+		remoteNode := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "node0"},
+		}
+		lxcMachine := &infrav1.LXCMachine{
+			ObjectMeta: metav1.ObjectMeta{Name: "node0", Namespace: "default"},
+		}
+
+		remoteClient := fake.NewFakeClient(remoteNode)
+		g := NewWithT(t)
+		g.Expect(cloudprovider.PatchNode(context.TODO(), remoteClient, lxcMachine)).NotTo(HaveOccurred())
+
+		node := &corev1.Node{}
+		g.Expect(remoteClient.Get(context.TODO(), client.ObjectKeyFromObject(remoteNode), node)).NotTo(HaveOccurred())
+		g.Expect(node.Spec.ProviderID).To(Equal("lxc:///node0"))
+	})
+
+	t.Run("CloudProviderTaint", func(t *testing.T) {
+		remoteNode := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "node0"},
+			Spec: corev1.NodeSpec{
+				Taints: []corev1.Taint{
+					{Key: "something", Effect: "NoSchedule"},
+					{Key: "node.cloudprovider.kubernetes.io/uninitialized", Effect: "NoSchedule"},
+				},
+			},
+			Status: corev1.NodeStatus{
+				Addresses: []corev1.NodeAddress{
+					{Type: corev1.NodeHostName, Address: "node0"},
+					{Type: corev1.NodeInternalIP, Address: "10.0.0.20"},
+				},
+			},
+		}
+		lxcMachine := &infrav1.LXCMachine{
+			ObjectMeta: metav1.ObjectMeta{Name: "node0", Namespace: "default"},
+			Status: infrav1.LXCMachineStatus{
+				Addresses: []clusterv1.MachineAddress{
+					{Type: clusterv1.MachineHostName, Address: "node0"},
+					{Type: clusterv1.MachineInternalIP, Address: "10.0.0.10"},
+					{Type: clusterv1.MachineExternalIP, Address: "10.0.0.10"},
+					{Type: clusterv1.MachineInternalIP, Address: "10.0.0.20"},
+					{Type: clusterv1.MachineExternalIP, Address: "10.0.0.20"},
+				},
+			},
+		}
+
+		remoteClient := fake.NewFakeClient(remoteNode)
+		g := NewWithT(t)
+		g.Expect(cloudprovider.PatchNode(context.TODO(), remoteClient, lxcMachine)).NotTo(HaveOccurred())
+
+		node := &corev1.Node{}
+		g.Expect(remoteClient.Get(context.TODO(), client.ObjectKeyFromObject(remoteNode), node)).NotTo(HaveOccurred())
+		g.Expect(node.Spec.Taints).To(ConsistOf(
+			// cloud provider taint removed, other taints remain
+			corev1.Taint{Key: "something", Effect: "NoSchedule"}),
+		)
+		g.Expect(node.Status.Addresses).To(ConsistOf(
+			// original addresses
+			corev1.NodeAddress{Type: corev1.NodeHostName, Address: "node0"},
+			corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.20"},
+			// missing InternalIP address appended
+			corev1.NodeAddress{Type: corev1.NodeInternalIP, Address: "10.0.0.10"},
+		))
+	})
+}

--- a/internal/controller/lxcmachine/controller.go
+++ b/internal/controller/lxcmachine/controller.go
@@ -18,12 +18,15 @@ package lxcmachine
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/klog/v2"
 	clusterv1 "sigs.k8s.io/cluster-api/api/v1beta1"
+	"sigs.k8s.io/cluster-api/controllers/clustercache"
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/finalizers"
 	utillog "sigs.k8s.io/cluster-api/util/log"
@@ -44,6 +47,7 @@ import (
 // LXCMachineReconciler reconciles a LXCMachine object
 type LXCMachineReconciler struct {
 	client.Client
+	ClusterCache clustercache.ClusterCache
 
 	// WatchFilterValue is the label value used to filter events prior to reconciliation.
 	WatchFilterValue string
@@ -162,13 +166,22 @@ func (r *LXCMachineReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		return ctrl.Result{}, r.reconcileDelete(ctx, cluster, lxcCluster, machine, lxcMachine, lxcClient)
 	}
 
-	return r.reconcileNormal(ctx, cluster, lxcCluster, machine, lxcMachine, lxcClient)
+	result, err := r.reconcileNormal(ctx, cluster, lxcCluster, machine, lxcMachine, lxcClient)
+	// Requeue if the reconcile failed because the ClusterCacheTracker was locked for the
+	// current cluster because of concurrent access.
+	if errors.Is(err, clustercache.ErrClusterNotConnected) {
+		log.V(5).Info("Requeuing because connection to the workload cluster is down")
+		return ctrl.Result{RequeueAfter: time.Minute}, nil
+	}
+	return result, err
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *LXCMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager, options controller.Options) error {
 	if r.Client == nil {
 		return fmt.Errorf("required field Client must not be nil")
+	} else if r.ClusterCache == nil {
+		return fmt.Errorf("required field ClusterCache must not be nil")
 	}
 
 	predicateLog := ctrl.LoggerFrom(ctx).WithValues("controller", "lxcmachine")
@@ -196,6 +209,7 @@ func (r *LXCMachineReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Ma
 				predicates.ClusterPausedTransitionsOrInfrastructureReady(mgr.GetScheme(), predicateLog),
 			),
 		).
+		WatchesRawSource(r.ClusterCache.GetClusterSource("lxcmachine", clusterToLXCMachines)).
 		Complete(r); err != nil {
 		return fmt.Errorf("failed setting up with a controller manager: %w", err)
 	}

--- a/internal/controller/lxcmachine/controller_normal.go
+++ b/internal/controller/lxcmachine/controller_normal.go
@@ -10,9 +10,11 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 	"sigs.k8s.io/cluster-api/util/conditions"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 
 	infrav1 "github.com/lxc/cluster-api-provider-incus/api/v1alpha2"
+	"github.com/lxc/cluster-api-provider-incus/internal/cloudprovider"
 	"github.com/lxc/cluster-api-provider-incus/internal/loadbalancer"
 	"github.com/lxc/cluster-api-provider-incus/internal/lxc"
 	"github.com/lxc/cluster-api-provider-incus/internal/ptr"
@@ -95,6 +97,28 @@ func (r *LXCMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 			return ctrl.Result{}, fmt.Errorf("failed to update loadbalancer configuration: %w", err)
 		}
 		lxcMachine.Status.LoadBalancerConfigured = true
+	}
+
+	if lxcCluster.Spec.CloudProviderNodePatch {
+		// If the Cluster is using a control plane and the control plane is not yet initialized, there is no API server
+		// to contact to get the ProviderID for the Node hosted on this machine, so return early.
+		// NOTE: We are using RequeueAfter with a short interval in order to make test execution time more stable.
+		// NOTE: If the Cluster doesn't use a control plane, the ControlPlaneInitialized condition is only
+		// set to true after a control plane machine has a node ref. If we would requeue here in this case, the
+		// Machine will never get a node ref as ProviderID is required to set the node ref, so we would get a deadlock.
+		if cluster.Spec.ControlPlaneRef != nil && !conditions.IsTrue(cluster, clusterv1.ControlPlaneInitializedCondition) {
+			log.FromContext(ctx).Info("Waiting for initialized ControlPlane")
+			return ctrl.Result{RequeueAfter: 15 * time.Second}, nil
+		}
+
+		remoteClient, err := r.ClusterCache.GetClient(ctx, client.ObjectKeyFromObject(cluster))
+		if err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to generate workload cluster client: %w", err)
+		}
+
+		if err := cloudprovider.PatchNode(ctx, remoteClient, lxcMachine); err != nil {
+			return ctrl.Result{}, fmt.Errorf("failed to apply cloud-provider node patch: %w", err)
+		}
 	}
 
 	lxcMachine.Spec.ProviderID = ptr.To(lxcMachine.GetExpectedProviderID())


### PR DESCRIPTION

<!--
  Thank you for making cluster-api-provider-incus better. Please fill the template below
  with more details.
-->

#### Summary

Closes #191 

#### Changes
<!-- Please explain the list of changes made in this PR. Mention any user-facing changes. -->

In https://github.com/lxc/cluster-api-provider-incus/pull/64/, we removed the cloud provider node patch, in favor of seeing the provider-id as a kubelet argument. However, this is not always easy across different control plane and bootstrap providers (e.g. Talos).

We introduce a new opt-in field LXCCluster.spec.cloudProviderNodePatch. When set to true, CAPN will patch the spec.providerID of remote nodes.

This field is not used in the default templates. To enable this behavior, the LXCCluster must be created as follows:

```
spec:
  cloudProviderNodePatch: true
```


#### Testing
<!-- Please explain how you tested your changes. -->

Manually bring up a cluster using the development cluster template, remove provider-id kubelet argument and set `spec.cloudProviderNodePatch: true` on the LXCCluster.

#### Possible Regressions
<!-- (This section is optional). Could these changes introduce regressions in existing functionality? -->

The clustercache might increase some of the noise in the logs, but that should not be an issue.

#### Checklist
<!-- Please verify that you have done the following -->

* [X] The introduced changes are covered by unit and/or integration tests.

#### Notes
<!-- Please add any other information that you think may be relevant -->
