### PR TITLE
Add LXCCluster.spec.{lxc,oci}.disableHealthzCheck

### DIFF
--- a/api/v1alpha2/lxccluster_types.go
+++ b/api/v1alpha2/lxccluster_types.go
@@ -152,6 +152,13 @@ type LXCLoadBalancerInstance struct {
 	// +optional
 	InstanceSpec LXCLoadBalancerMachineSpec `json:"instanceSpec,omitempty"`
 
+	// DisableHealthzCheck allows disabling the HAProxy /healthz check on kube-apiserver endpoints.
+	//
+	// This is useful in scenarios where anonymous-auth=true is set on the kube-apiserver, in which case the haproxy check will always fail.
+	//
+	// +optional
+	DisableHealthzCheck bool `json:"disableHealthzCheck,omitempty"`
+
 	// CustomHAProxyConfigTemplate allows you to replace the default HAProxy config file content.
 	// Please use it with caution, as there are no checks to ensure the validity of the configuration.
 	// +optional

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclusters.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclusters.yaml
@@ -146,6 +146,12 @@ spec:
                           CustomHAProxyConfigTemplate allows you to replace the default HAProxy config file content.
                           Please use it with caution, as there are no checks to ensure the validity of the configuration.
                         type: string
+                      disableHealthzCheck:
+                        description: |-
+                          DisableHealthzCheck allows disabling the HAProxy /healthz check on kube-apiserver endpoints.
+
+                          This is useful in scenarios where anonymous-auth=true is set on the kube-apiserver, in which case the haproxy check will always fail.
+                        type: boolean
                       instanceSpec:
                         description: InstanceSpec can be used to adjust the load balancer
                           instance configuration.
@@ -244,6 +250,12 @@ spec:
                           CustomHAProxyConfigTemplate allows you to replace the default HAProxy config file content.
                           Please use it with caution, as there are no checks to ensure the validity of the configuration.
                         type: string
+                      disableHealthzCheck:
+                        description: |-
+                          DisableHealthzCheck allows disabling the HAProxy /healthz check on kube-apiserver endpoints.
+
+                          This is useful in scenarios where anonymous-auth=true is set on the kube-apiserver, in which case the haproxy check will always fail.
+                        type: boolean
                       instanceSpec:
                         description: InstanceSpec can be used to adjust the load balancer
                           instance configuration.

--- a/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclustertemplates.yaml
+++ b/config/crd/bases/infrastructure.cluster.x-k8s.io_lxcclustertemplates.yaml
@@ -166,6 +166,12 @@ spec:
                                   CustomHAProxyConfigTemplate allows you to replace the default HAProxy config file content.
                                   Please use it with caution, as there are no checks to ensure the validity of the configuration.
                                 type: string
+                              disableHealthzCheck:
+                                description: |-
+                                  DisableHealthzCheck allows disabling the HAProxy /healthz check on kube-apiserver endpoints.
+
+                                  This is useful in scenarios where anonymous-auth=true is set on the kube-apiserver, in which case the haproxy check will always fail.
+                                type: boolean
                               instanceSpec:
                                 description: InstanceSpec can be used to adjust the
                                   load balancer instance configuration.
@@ -265,6 +271,12 @@ spec:
                                   CustomHAProxyConfigTemplate allows you to replace the default HAProxy config file content.
                                   Please use it with caution, as there are no checks to ensure the validity of the configuration.
                                 type: string
+                              disableHealthzCheck:
+                                description: |-
+                                  DisableHealthzCheck allows disabling the HAProxy /healthz check on kube-apiserver endpoints.
+
+                                  This is useful in scenarios where anonymous-auth=true is set on the kube-apiserver, in which case the haproxy check will always fail.
+                                type: boolean
                               instanceSpec:
                                 description: InstanceSpec can be used to adjust the
                                   load balancer instance configuration.

--- a/internal/loadbalancer/config.go
+++ b/internal/loadbalancer/config.go
@@ -31,6 +31,7 @@ type configData struct {
 	BackendControlPlanePort  string
 	BackendServers           map[string]backendServer
 	IPv6                     bool
+	EnableHealthzCheck       bool
 }
 
 // backendServer defines a loadbalancer backend.
@@ -78,7 +79,9 @@ frontend control-plane
   default_backend kube-apiservers
 
 backend kube-apiservers
+  {{ if .EnableHealthzCheck -}}
   option httpchk GET /healthz
+  {{- end }}
   {{range $server, $backend := .BackendServers}}
   server {{ $server }} {{ JoinHostPort $backend.Address $.BackendControlPlanePort }} weight {{ $backend.Weight }} check check-ssl verify none
   {{- end}}

--- a/internal/loadbalancer/manager.go
+++ b/internal/loadbalancer/manager.go
@@ -35,8 +35,10 @@ func ManagerForCluster(cluster *clusterv1.Cluster, lxcCluster *infrav1.LXCCluste
 			clusterName:      cluster.Name,
 			clusterNamespace: cluster.Namespace,
 
-			name:                        lxcCluster.GetLoadBalancerInstanceName(),
-			spec:                        lxcCluster.Spec.LoadBalancer.LXC.InstanceSpec,
+			name: lxcCluster.GetLoadBalancerInstanceName(),
+			spec: lxcCluster.Spec.LoadBalancer.LXC.InstanceSpec,
+
+			enableHealthzCheck:          !lxcCluster.Spec.LoadBalancer.LXC.DisableHealthzCheck,
 			customHAProxyConfigTemplate: lxcCluster.Spec.LoadBalancer.LXC.CustomHAProxyConfigTemplate,
 		}
 	case lxcCluster.Spec.LoadBalancer.OCI != nil:
@@ -45,8 +47,10 @@ func ManagerForCluster(cluster *clusterv1.Cluster, lxcCluster *infrav1.LXCCluste
 			clusterName:      cluster.Name,
 			clusterNamespace: cluster.Namespace,
 
-			name:                        lxcCluster.GetLoadBalancerInstanceName(),
-			spec:                        lxcCluster.Spec.LoadBalancer.OCI.InstanceSpec,
+			name: lxcCluster.GetLoadBalancerInstanceName(),
+			spec: lxcCluster.Spec.LoadBalancer.OCI.InstanceSpec,
+
+			enableHealthzCheck:          !lxcCluster.Spec.LoadBalancer.OCI.DisableHealthzCheck,
 			customHAProxyConfigTemplate: lxcCluster.Spec.LoadBalancer.OCI.CustomHAProxyConfigTemplate,
 		}
 	case lxcCluster.Spec.LoadBalancer.OVN != nil:

--- a/internal/loadbalancer/manager_lxc.go
+++ b/internal/loadbalancer/manager_lxc.go
@@ -24,6 +24,7 @@ type managerLXC struct {
 	name string
 	spec infrav1.LXCLoadBalancerMachineSpec
 
+	enableHealthzCheck          bool
 	customHAProxyConfigTemplate string
 }
 
@@ -78,6 +79,7 @@ func (l *managerLXC) Reconfigure(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to build load balancer configuration: %w", err)
 	}
+	config.EnableHealthzCheck = l.enableHealthzCheck
 
 	haproxyTemplate := DefaultHaproxyTemplate
 	if l.customHAProxyConfigTemplate != "" {

--- a/internal/loadbalancer/manager_oci.go
+++ b/internal/loadbalancer/manager_oci.go
@@ -25,6 +25,7 @@ type managerOCI struct {
 	name string
 	spec infrav1.LXCLoadBalancerMachineSpec
 
+	enableHealthzCheck          bool
 	customHAProxyConfigTemplate string
 }
 
@@ -83,6 +84,7 @@ func (l *managerOCI) Reconfigure(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to build load balancer configuration: %w", err)
 	}
+	config.EnableHealthzCheck = l.enableHealthzCheck
 
 	haproxyCfgTemplate := DefaultHaproxyTemplate
 	if l.customHAProxyConfigTemplate != "" {


### PR DESCRIPTION
#### Summary

References #191 

This allows disabling the default haproxy HTTP check for apiserver endpoints, in situations where anonymous-auth=false is set on kube-apiserver.

For example, when using the Talos provider with default configuration.
