### PR TITLE
bump kube-flannel v0.27.3 -> v0.28.4

### DIFF
--- a/cmd/exp/image-builder/cmd/default.go
+++ b/cmd/exp/image-builder/cmd/default.go
@@ -19,7 +19,7 @@ var (
 	defaultPullExtraImages = []string{
 		// images for default flannel CNI
 		// NOTE(neoaggelos): keep up to date with flannel CNI manifest in ./templates/cluster-template.yaml
-		"ghcr.io/flannel-io/flannel-cni-plugin:v1.7.1-flannel1",
-		"ghcr.io/flannel-io/flannel:v0.27.3",
+		"ghcr.io/flannel-io/flannel-cni-plugin:v1.9.1-flannel1",
+		"ghcr.io/flannel-io/flannel:v0.28.4",
 	}
 )

--- a/internal/static/embed/kube-flannel.yaml
+++ b/internal/static/embed/kube-flannel.yaml
@@ -1,4 +1,4 @@
-# Sourced from: https://github.com/flannel-io/flannel/releases/download/v0.27.3/kube-flannel.yml
+# Sourced from: https://github.com/flannel-io/flannel/releases/download/v0.28.4/kube-flannel.yml
 # Changes:
 # - configmap: make sure kind can properly template .PodSubnet
 
@@ -152,7 +152,7 @@ spec:
           value: "5000"
         - name: CONT_WHEN_CACHE_NOT_READY
           value: "false"
-        image: ghcr.io/flannel-io/flannel:v0.27.3
+        image: ghcr.io/flannel-io/flannel:v0.28.4
         name: kube-flannel
         resources:
           requests:
@@ -179,7 +179,7 @@ spec:
         - /opt/cni/bin/flannel
         command:
         - cp
-        image: ghcr.io/flannel-io/flannel-cni-plugin:v1.7.1-flannel1
+        image: ghcr.io/flannel-io/flannel-cni-plugin:v1.9.1-flannel1
         name: install-cni-plugin
         volumeMounts:
         - mountPath: /opt/cni/bin
@@ -190,7 +190,7 @@ spec:
         - /etc/cni/net.d/10-flannel.conflist
         command:
         - cp
-        image: ghcr.io/flannel-io/flannel:v0.27.3
+        image: ghcr.io/flannel-io/flannel:v0.28.4
         name: install-cni
         volumeMounts:
         - mountPath: /etc/cni/net.d

--- a/templates/cluster-template-autoscaler.yaml
+++ b/templates/cluster-template-autoscaler.yaml
@@ -82,7 +82,7 @@ metadata:
   name: ${CLUSTER_NAME}-kube-flannel
 data:
   cni.yaml: |
-    # Sourced from: https://github.com/flannel-io/flannel/releases/download/v0.27.3/kube-flannel.yml
+    # Sourced from: https://github.com/flannel-io/flannel/releases/download/v0.28.4/kube-flannel.yml
 
     apiVersion: v1
     kind: Namespace
@@ -231,7 +231,7 @@ data:
               value: "5000"
             - name: CONT_WHEN_CACHE_NOT_READY
               value: "false"
-            image: ghcr.io/flannel-io/flannel:v0.27.3
+            image: ghcr.io/flannel-io/flannel:v0.28.4
             name: kube-flannel
             resources:
               requests:
@@ -258,7 +258,7 @@ data:
             - /opt/cni/bin/flannel
             command:
             - cp
-            image: ghcr.io/flannel-io/flannel-cni-plugin:v1.7.1-flannel1
+            image: ghcr.io/flannel-io/flannel-cni-plugin:v1.9.1-flannel1
             name: install-cni-plugin
             volumeMounts:
             - mountPath: /opt/cni/bin
@@ -269,7 +269,7 @@ data:
             - /etc/cni/net.d/10-flannel.conflist
             command:
             - cp
-            image: ghcr.io/flannel-io/flannel:v0.27.3
+            image: ghcr.io/flannel-io/flannel:v0.28.4
             name: install-cni
             volumeMounts:
             - mountPath: /etc/cni/net.d

--- a/templates/cluster-template.yaml
+++ b/templates/cluster-template.yaml
@@ -81,7 +81,7 @@ metadata:
   name: ${CLUSTER_NAME}-kube-flannel
 data:
   cni.yaml: |
-    # Sourced from: https://github.com/flannel-io/flannel/releases/download/v0.27.3/kube-flannel.yml
+    # Sourced from: https://github.com/flannel-io/flannel/releases/download/v0.28.4/kube-flannel.yml
 
     apiVersion: v1
     kind: Namespace
@@ -230,7 +230,7 @@ data:
               value: "5000"
             - name: CONT_WHEN_CACHE_NOT_READY
               value: "false"
-            image: ghcr.io/flannel-io/flannel:v0.27.3
+            image: ghcr.io/flannel-io/flannel:v0.28.4
             name: kube-flannel
             resources:
               requests:
@@ -257,7 +257,7 @@ data:
             - /opt/cni/bin/flannel
             command:
             - cp
-            image: ghcr.io/flannel-io/flannel-cni-plugin:v1.7.1-flannel1
+            image: ghcr.io/flannel-io/flannel-cni-plugin:v1.9.1-flannel1
             name: install-cni-plugin
             volumeMounts:
             - mountPath: /opt/cni/bin
@@ -268,7 +268,7 @@ data:
             - /etc/cni/net.d/10-flannel.conflist
             command:
             - cp
-            image: ghcr.io/flannel-io/flannel:v0.27.3
+            image: ghcr.io/flannel-io/flannel:v0.28.4
             name: install-cni
             volumeMounts:
             - mountPath: /etc/cni/net.d


### PR DESCRIPTION
### Summary

This will affect e2e tests, as Flannel images from older kubeadm images will be different version.

Only merge this PR when ready to release new images.