### PR TITLE
add `ubuntu:26.04` as supported base for image builder

### DIFF
--- a/cmd/exp/image-builder/cmd/base_images.go
+++ b/cmd/exp/image-builder/cmd/base_images.go
@@ -22,6 +22,11 @@ var wellKnownBaseImages = map[string]baseImageInfo{
 		releaseName: "noble",
 		variantName: "ubuntu",
 	},
+	"ubuntu:26.04": {
+		fullName:    "ubuntu resolute",
+		releaseName: "resolute",
+		variantName: "ubuntu",
+	},
 	"debian:12": {
 		fullName:    "debian bookworm",
 		releaseName: "bookworm",

--- a/cmd/exp/image-builder/cmd/cmd_haproxy.go
+++ b/cmd/exp/image-builder/cmd/cmd_haproxy.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"maps"
 	"runtime"
+	"slices"
 
 	"github.com/lxc/incus/v6/shared/api"
 	"github.com/spf13/cobra"
@@ -50,9 +52,9 @@ func newHaproxyCmd() *cobra.Command {
 				flags.baseImage = "debian:13"
 			case "ubuntu":
 				flags.baseImage = "ubuntu:24.04"
-			case "debian:12", "debian:13", "ubuntu:22.04", "ubuntu:24.04":
-			default:
-				return fmt.Errorf("invalid value for --base-image argument %q, must be one of [ubuntu:22.04, ubuntu:24.04, debian:12, debian:13]", flags.baseImage)
+			}
+			if _, ok := wellKnownBaseImages[flags.baseImage]; !ok {
+				return fmt.Errorf("invalid value for --base-image argument %q, must be one of %v", flags.baseImage, slices.Collect(maps.Keys(wellKnownBaseImages)))
 			}
 
 			if flags.imageAlias == "" {
@@ -119,7 +121,7 @@ func newHaproxyCmd() *cobra.Command {
 		"Override remote to use from configuration file")
 
 	cmd.Flags().StringVar(&flags.baseImage, "base-image", defaultBaseImage,
-		"Base image for launching builder instance (one of ubuntu:22.04|ubuntu:24.04|debian:12|debian:13)")
+		fmt.Sprintf("Base image for launching builder instance (%v)", slices.Collect(maps.Keys(wellKnownBaseImages))))
 
 	cmd.Flags().StringVar(&flags.instanceName, "instance-name", defaultInstanceName,
 		"Name for the builder instance")

--- a/cmd/exp/image-builder/cmd/cmd_kubeadm.go
+++ b/cmd/exp/image-builder/cmd/cmd_kubeadm.go
@@ -2,7 +2,9 @@ package cmd
 
 import (
 	"fmt"
+	"maps"
 	"runtime"
+	"slices"
 	"time"
 
 	"github.com/blang/semver/v4"
@@ -66,9 +68,9 @@ func newKubeadmCmd() *cobra.Command {
 				flags.baseImage = "debian:13"
 			case "ubuntu":
 				flags.baseImage = "ubuntu:24.04"
-			case "debian:12", "debian:13", "ubuntu:22.04", "ubuntu:24.04":
-			default:
-				return fmt.Errorf("invalid value for --base-image argument %q, must be one of [ubuntu:22.04, ubuntu:24.04, debian:12, debian:13]", flags.baseImage)
+			}
+			if _, ok := wellKnownBaseImages[flags.baseImage]; !ok {
+				return fmt.Errorf("invalid value for --base-image argument %q, must be one of %v", flags.baseImage, slices.Collect(maps.Keys(wellKnownBaseImages)))
 			}
 
 			if flags.imageAlias == "" {
@@ -153,7 +155,7 @@ func newKubeadmCmd() *cobra.Command {
 		"Override remote to use from configuration file")
 
 	cmd.Flags().StringVar(&flags.baseImage, "base-image", defaultBaseImage,
-		"Base image for launching builder instance (one of ubuntu:22.04|ubuntu:24.04|debian:12|debian:13)")
+		fmt.Sprintf("Base image for launching builder instance (%v)", slices.Collect(maps.Keys(wellKnownBaseImages))))
 
 	cmd.Flags().StringVar(&flags.instanceName, "instance-name", defaultInstanceName,
 		"Name for the builder instance")


### PR DESCRIPTION
### Summary

Enable building kubeadm and haproxy images based on `ubuntu:26.04`