### PR TITLE
Updates to base image builder script

### DIFF
--- a/internal/static/embed/install-kubeadm.sh
+++ b/internal/static/embed/install-kubeadm.sh
@@ -152,22 +152,6 @@ OOMScoreAdjust=-999
 WantedBy=multi-user.target
 '
 
-KUBELET_SERVICE_LOCAL_STORAGE_CAPACITY_ISOLATION_DROPIN_CONFIG='
-# [v1.36+] When /var/lib/kubelet is on zfs and /dev/zfs is not available, try to ensure --local-storage-capacity-isolation=false kubelet flag is used
-# Otherwise, kubelet will fail to start with:
-#   kubelet.go:1821] "Failed to start ContainerManager" err="failed to get rootfs info: cannot find filesystem info for device \"zfs/containers/c1-md-0-wzh7h-qfkzt-z9bfr\""
-[Service]
-ExecStartPre=bash -xe -c "\
- mkdir -p /etc/sysconfig && \
- if df /var/lib/kubelet | grep zfs && [ ! -f /dev/zfs ] && ! cat /etc/sysconfig/kubelet | grep -- --local-storage-capacity-isolation=false; then \
-  if cat /etc/sysconfig/kubelet | grep KUBELET_EXTRA_ARGS=; then \
-   sed \"s,KUBELET_EXTRA_ARGS=,KUBELET_EXTRA_ARGS=--local-storage-capacity-isolation=false ,\" -i /etc/sysconfig/kubelet ; \
-  else \
-   echo KUBELET_EXTRA_ARGS=--local-storage-capacity-isolation=false | tee -a /etc/sysconfig/kubelet ; \
-  fi; \
- fi"
-'
-
 CONTAINERD_SERVICE_UNPRIVILEGED_MODE_DROPIN_CONFIG='
 [Service]
 ExecStartPre=bash -xe -c "\
@@ -176,7 +160,7 @@ ExecStartPre=bash -xe -c "\
   [ -f config.default.toml ] && ln -sf config.default.toml config.toml; \
  else \
   [ -f config.unprivileged.toml ] && ln -sf config.unprivileged.toml config.toml; \
- fi"
+fi"
 '
 
 # infer ARCH
@@ -244,7 +228,6 @@ mkdir -p /usr/lib/systemd/system/kubelet.service.d
 if ! systemctl list-unit-files kubelet.service &>/dev/null; then
   echo "${KUBELET_SERVICE}" | tee /usr/lib/systemd/system/kubelet.service
   echo "${KUBELET_SERVICE_KUBEADM_DROPIN_CONFIG}" | tee /usr/lib/systemd/system/kubelet.service.d/10-kubeadm.conf
-  echo "${KUBELET_SERVICE_LOCAL_STORAGE_CAPACITY_ISOLATION_DROPIN_CONFIG}" | tee /usr/lib/systemd/system/kubelet.service.d/15-local-storage-capacity-isolation.conf
 fi
 systemctl enable kubelet.service
 

--- a/internal/static/embed/install-kubeadm.sh
+++ b/internal/static/embed/install-kubeadm.sh
@@ -7,7 +7,7 @@ set -xeu
 
 KUBERNETES_VERSION="${KUBERNETES_VERSION:-$1}"            # https://dl.k8s.io/release/stable.txt or https://dl.k8s.io/release/stable-1.32.txt
 CNI_PLUGINS_VERSION="${CNI_PLUGINS_VERSION:-v1.9.1}"      # https://github.com/containernetworking/plugins
-CRICTL_VERSION="${CRICTL_VERSION:-v1.35.0}"               # https://github.com/kubernetes-sigs/cri-tools
+CRICTL_VERSION="${CRICTL_VERSION:-v1.36.0}"               # https://github.com/kubernetes-sigs/cri-tools
 CONTAINERD_VERSION="${CONTAINERD_VERSION:-v2.3.0}"        # https://github.com/containerd/containerd
 RUNC_VERSION="${RUNC_VERSION:-v1.4.2}"                    # https://github.com/opencontainers/runc, must match https://raw.githubusercontent.com/containerd/containerd/v2.3.0/script/setup/runc-version
 

--- a/internal/static/embed/install-kubeadm.sh
+++ b/internal/static/embed/install-kubeadm.sh
@@ -250,3 +250,4 @@ systemctl enable kubelet.service
 
 # pull images
 kubeadm config images pull --kubernetes-version "${KUBERNETES_VERSION}"
+crictl pull "registry.k8s.io/pause:3.10.2"

--- a/internal/static/embed/install-kubeadm.sh
+++ b/internal/static/embed/install-kubeadm.sh
@@ -8,8 +8,8 @@ set -xeu
 KUBERNETES_VERSION="${KUBERNETES_VERSION:-$1}"            # https://dl.k8s.io/release/stable.txt or https://dl.k8s.io/release/stable-1.32.txt
 CNI_PLUGINS_VERSION="${CNI_PLUGINS_VERSION:-v1.9.1}"      # https://github.com/containernetworking/plugins
 CRICTL_VERSION="${CRICTL_VERSION:-v1.35.0}"               # https://github.com/kubernetes-sigs/cri-tools
-CONTAINERD_VERSION="${CONTAINERD_VERSION:-v2.2.3}"        # https://github.com/containerd/containerd
-RUNC_VERSION="${RUNC_VERSION:-v1.3.5}"                    # https://github.com/opencontainers/runc, must match https://raw.githubusercontent.com/containerd/containerd/v2.2.3/script/setup/runc-version
+CONTAINERD_VERSION="${CONTAINERD_VERSION:-v2.3.0}"        # https://github.com/containerd/containerd
+RUNC_VERSION="${RUNC_VERSION:-v1.4.2}"                    # https://github.com/opencontainers/runc, must match https://raw.githubusercontent.com/containerd/containerd/v2.3.0/script/setup/runc-version
 
 KUBELET_SERVICE='
 # Sourced from: https://raw.githubusercontent.com/kubernetes/release/v0.21.0/cmd/krel/templates/latest/kubelet/kubelet.service


### PR DESCRIPTION
### Summary

- update containerd v2.2.3 -> v2.3.0
- update runc v1.3.5 -> v1.4.2
- update crictl v1.35.0 -> v1.36.0
- ensure the pinned pause image exists
- do not disable --local-storage-capacity-isolation on zfs, this is actually a kubelet regression in v1.36.0 https://github.com/kubernetes/kubernetes/pull/138590
