### PR TITLE
Remove cgroupv1 configuration from default kubeadm profiles

### DIFF
--- a/hack/scripts/ci/setup-e2e-resources.sh
+++ b/hack/scripts/ci/setup-e2e-resources.sh
@@ -61,4 +61,7 @@ fi
 
 # configure default profile
 "${CLI}" profile device set "${LXC_PROFILE_NAME}" eth0 type=nic network="${LXC_NETWORK_NAME}"
+
+# print server and profile information
+"${CLI}" info
 "${CLI}" profile show default

--- a/internal/static/embed/kind.yaml
+++ b/internal/static/embed/kind.yaml
@@ -3,8 +3,7 @@ config:
   linux.kernel_modules: ip_vs,ip_vs_rr,ip_vs_wrr,ip_vs_sh,ip_tables,ip6_tables,iptable_raw,netlink_diag,nf_nat,overlay,br_netfilter,xt_socket
   raw.lxc: |
     lxc.apparmor.profile=unconfined
-    lxc.mount.auto=proc:rw sys:rw cgroup:rw
-    lxc.cgroup.devices.allow=a
+    lxc.mount.auto=proc:rw sys:rw
     lxc.cap.drop=
   security.privileged: "true"
   oci.entrypoint: /init /sbin/init

--- a/internal/static/embed/kubeadm.yaml
+++ b/internal/static/embed/kubeadm.yaml
@@ -3,8 +3,7 @@ config:
   linux.kernel_modules: ip_vs,ip_vs_rr,ip_vs_wrr,ip_vs_sh,ip_tables,ip6_tables,iptable_raw,netlink_diag,nf_nat,overlay,br_netfilter,xt_socket
   raw.lxc: |
     lxc.apparmor.profile=unconfined
-    lxc.mount.auto=proc:rw sys:rw cgroup:rw
-    lxc.cgroup.devices.allow=a
+    lxc.mount.auto=proc:rw sys:rw
     lxc.cap.drop=
   security.nesting: "true"
   security.privileged: "true"


### PR DESCRIPTION
### Summary

Now that [Incus 7.0](https://github.com/lxc/incus/releases/tag/v7.0.0) has removed cgroupv1 support, also remove cgroupv1 configuration from `raw.lxc` in the default profiles.

This configuration is only necessary in older kernels with cgroupv1 or unified cgroups. This means cluster-api-provider-incus `v0.8.6` will be the last version to include cgroupv1 handling in the default kubeadm profiles.