### PR TITLE
use new(expr) instead of ptr.To[type](expr)

### DIFF
--- a/internal/controller/lxccluster/controller_normal.go
+++ b/internal/controller/lxccluster/controller_normal.go
@@ -12,7 +12,6 @@ import (
 	infrav1 "github.com/lxc/cluster-api-provider-incus/api/v1alpha2"
 	"github.com/lxc/cluster-api-provider-incus/internal/loadbalancer"
 	"github.com/lxc/cluster-api-provider-incus/internal/lxc"
-	"github.com/lxc/cluster-api-provider-incus/internal/ptr"
 	"github.com/lxc/cluster-api-provider-incus/internal/utils"
 )
 
@@ -40,7 +39,7 @@ func (r *LXCClusterReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	}
 
 	// Mark the lxcCluster ready
-	lxcCluster.Status.Initialization.Provisioned = ptr.To(true)
+	lxcCluster.Status.Initialization.Provisioned = new(true)
 	conditions.Set(lxcCluster, metav1.Condition{Type: infrav1.LoadBalancerAvailableCondition, Status: metav1.ConditionTrue, Reason: infrav1.LoadBalancerProvisionedReason})
 
 	return nil

--- a/internal/controller/lxcmachine/controller_normal.go
+++ b/internal/controller/lxcmachine/controller_normal.go
@@ -46,7 +46,7 @@ func (r *LXCMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 			return ctrl.Result{}, err
 		}
 
-		lxcMachine.Status.Initialization.Provisioned = ptr.To(true)
+		lxcMachine.Status.Initialization.Provisioned = new(true)
 		conditions.Set(lxcMachine, metav1.Condition{Type: infrav1.InstanceProvisionedCondition, Status: metav1.ConditionTrue, Reason: infrav1.InstanceProvisionedReason})
 		r.setLXCMachineAddresses(lxcMachine, lxc.ParseHostAddresses(state))
 
@@ -142,7 +142,7 @@ func (r *LXCMachineReconciler) reconcileNormal(ctx context.Context, cluster *clu
 	}
 
 	lxcMachine.Spec.ProviderID = lxcMachine.GetExpectedProviderID()
-	lxcMachine.Status.Initialization.Provisioned = ptr.To(true)
+	lxcMachine.Status.Initialization.Provisioned = new(true)
 
 	return ctrl.Result{RequeueAfter: 10 * time.Second}, nil
 }

--- a/internal/ptr/ptr.go
+++ b/internal/ptr/ptr.go
@@ -1,10 +1,5 @@
 package ptr
 
-// To returns a pointer to the given value.
-func To[T any](v T) *T {
-	return &v
-}
-
 // Deref returns value from pointer or default value.
 func Deref[T any](v *T, or T) T {
 	if v == nil {

--- a/test/e2e/suites/e2e/autoscaler_test.go
+++ b/test/e2e/suites/e2e/autoscaler_test.go
@@ -7,7 +7,6 @@ import (
 
 	"sigs.k8s.io/cluster-api/test/e2e"
 
-	"github.com/lxc/cluster-api-provider-incus/internal/ptr"
 	"github.com/lxc/cluster-api-provider-incus/test/e2e/shared"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -23,9 +22,9 @@ var _ = Describe("Autoscaler", func() {
 			ArtifactFolder:         e2eCtx.Settings.ArtifactFolder,
 			SkipCleanup:            e2eCtx.Settings.SkipCleanup,
 			PostNamespaceCreated:   e2eCtx.DefaultPostNamespaceCreated(),
-			InfrastructureProvider: ptr.To("incus:v0.88.99"),
+			InfrastructureProvider: new("incus:v0.88.99"),
 
-			Flavor: ptr.To(shared.FlavorAutoscaler),
+			Flavor: new(shared.FlavorAutoscaler),
 
 			InfrastructureMachineTemplateKind: "lxcmachinetemplates",
 			AutoscalerVersion:                 "v1.31.1",

--- a/test/e2e/suites/e2e/clusterclass_rollout_test.go
+++ b/test/e2e/suites/e2e/clusterclass_rollout_test.go
@@ -25,7 +25,7 @@ var _ = Describe("ClusterClassRollout", func() {
 			ArtifactFolder:         e2eCtx.Settings.ArtifactFolder,
 			SkipCleanup:            e2eCtx.Settings.SkipCleanup,
 			PostNamespaceCreated:   e2eCtx.DefaultPostNamespaceCreated(),
-			InfrastructureProvider: ptr.To("incus:v0.88.99"),
+			InfrastructureProvider: new("incus:v0.88.99"),
 
 			Flavor: shared.FlavorDefault,
 		}

--- a/test/e2e/suites/e2e/quick_start_debian_test.go
+++ b/test/e2e/suites/e2e/quick_start_debian_test.go
@@ -9,7 +9,6 @@ import (
 	"sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/util"
 
-	"github.com/lxc/cluster-api-provider-incus/internal/ptr"
 	"github.com/lxc/cluster-api-provider-incus/test/e2e/shared"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -33,12 +32,12 @@ var _ = Describe("QuickStart", func() {
 					ArtifactFolder:         e2eCtx.Settings.ArtifactFolder,
 					SkipCleanup:            e2eCtx.Settings.SkipCleanup,
 					PostNamespaceCreated:   e2eCtx.DefaultPostNamespaceCreated(),
-					InfrastructureProvider: ptr.To("incus:v0.88.99"),
+					InfrastructureProvider: new("incus:v0.88.99"),
 
-					Flavor:                   ptr.To(shared.FlavorDefault),
-					ControlPlaneMachineCount: ptr.To[int64](1),
-					WorkerMachineCount:       ptr.To[int64](1),
-					ClusterName:              ptr.To(fmt.Sprintf("capn-debian-%s", util.RandomString(4))),
+					Flavor:                   new(shared.FlavorDefault),
+					ControlPlaneMachineCount: new(int64(1)),
+					WorkerMachineCount:       new(int64(1)),
+					ClusterName:              new(fmt.Sprintf("capn-debian-%s", util.RandomString(4))),
 				}
 			})
 		})
@@ -52,12 +51,12 @@ var _ = Describe("QuickStart", func() {
 					ArtifactFolder:         e2eCtx.Settings.ArtifactFolder,
 					SkipCleanup:            e2eCtx.Settings.SkipCleanup,
 					PostNamespaceCreated:   e2eCtx.DefaultPostNamespaceCreated(),
-					InfrastructureProvider: ptr.To("incus:v0.88.99"),
+					InfrastructureProvider: new("incus:v0.88.99"),
 
-					Flavor:                   ptr.To(shared.FlavorDefault),
-					ControlPlaneMachineCount: ptr.To[int64](1),
-					WorkerMachineCount:       ptr.To[int64](1),
-					ClusterName:              ptr.To(fmt.Sprintf("capn-debian-unprivileged-%s", util.RandomString(4))),
+					Flavor:                   new(shared.FlavorDefault),
+					ControlPlaneMachineCount: new(int64(1)),
+					WorkerMachineCount:       new(int64(1)),
+					ClusterName:              new(fmt.Sprintf("capn-debian-unprivileged-%s", util.RandomString(4))),
 
 					ClusterctlVariables: map[string]string{"PRIVILEGED": "false"},
 				}

--- a/test/e2e/suites/e2e/quick_start_default_test.go
+++ b/test/e2e/suites/e2e/quick_start_default_test.go
@@ -9,7 +9,6 @@ import (
 	"sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/util"
 
-	"github.com/lxc/cluster-api-provider-incus/internal/ptr"
 	"github.com/lxc/cluster-api-provider-incus/test/e2e/shared"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -26,12 +25,12 @@ var _ = Describe("QuickStart", func() {
 					ArtifactFolder:         e2eCtx.Settings.ArtifactFolder,
 					SkipCleanup:            e2eCtx.Settings.SkipCleanup,
 					PostNamespaceCreated:   e2eCtx.DefaultPostNamespaceCreated(),
-					InfrastructureProvider: ptr.To("incus:v0.88.99"),
+					InfrastructureProvider: new("incus:v0.88.99"),
 
-					Flavor:                   ptr.To(shared.FlavorDefault),
-					ControlPlaneMachineCount: ptr.To[int64](3),
-					WorkerMachineCount:       ptr.To[int64](3),
-					ClusterName:              ptr.To(fmt.Sprintf("capn-default-%s", util.RandomString(4))),
+					Flavor:                   new(shared.FlavorDefault),
+					ControlPlaneMachineCount: new(int64(3)),
+					WorkerMachineCount:       new(int64(3)),
+					ClusterName:              new(fmt.Sprintf("capn-default-%s", util.RandomString(4))),
 				}
 			})
 		})
@@ -45,12 +44,12 @@ var _ = Describe("QuickStart", func() {
 					ArtifactFolder:         e2eCtx.Settings.ArtifactFolder,
 					SkipCleanup:            e2eCtx.Settings.SkipCleanup,
 					PostNamespaceCreated:   e2eCtx.DefaultPostNamespaceCreated(),
-					InfrastructureProvider: ptr.To("incus:v0.88.99"),
+					InfrastructureProvider: new("incus:v0.88.99"),
 
-					Flavor:                   ptr.To(shared.FlavorDefault),
-					ControlPlaneMachineCount: ptr.To[int64](3),
-					WorkerMachineCount:       ptr.To[int64](3),
-					ClusterName:              ptr.To(fmt.Sprintf("capn-default-unprivileged-%s", util.RandomString(4))),
+					Flavor:                   new(shared.FlavorDefault),
+					ControlPlaneMachineCount: new(int64(3)),
+					WorkerMachineCount:       new(int64(3)),
+					ClusterName:              new(fmt.Sprintf("capn-default-unprivileged-%s", util.RandomString(4))),
 
 					ClusterctlVariables: map[string]string{"PRIVILEGED": "false"},
 				}

--- a/test/e2e/suites/e2e/quick_start_kind_test.go
+++ b/test/e2e/suites/e2e/quick_start_kind_test.go
@@ -13,7 +13,6 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 
 	"github.com/lxc/cluster-api-provider-incus/internal/lxc"
-	"github.com/lxc/cluster-api-provider-incus/internal/ptr"
 	"github.com/lxc/cluster-api-provider-incus/internal/utils"
 	"github.com/lxc/cluster-api-provider-incus/test/e2e/shared"
 
@@ -87,12 +86,12 @@ var _ = Describe("QuickStart", func() {
 					ArtifactFolder:         e2eCtx.Settings.ArtifactFolder,
 					SkipCleanup:            e2eCtx.Settings.SkipCleanup,
 					PostNamespaceCreated:   e2eCtx.DefaultPostNamespaceCreated(),
-					InfrastructureProvider: ptr.To("incus:v0.88.99"),
+					InfrastructureProvider: new("incus:v0.88.99"),
 
-					Flavor:                   ptr.To(shared.FlavorDefault),
-					ControlPlaneMachineCount: ptr.To[int64](3),
-					WorkerMachineCount:       ptr.To[int64](1),
-					ClusterName:              ptr.To(fmt.Sprintf("capn-kind-%s", util.RandomString(4))),
+					Flavor:                   new(shared.FlavorDefault),
+					ControlPlaneMachineCount: new(int64(3)),
+					WorkerMachineCount:       new(int64(1)),
+					ClusterName:              new(fmt.Sprintf("capn-kind-%s", util.RandomString(4))),
 
 					ControlPlaneWaiters: clusterctl.ControlPlaneWaiters{
 						WaitForControlPlaneMachinesReady: applyDefaultKindCNI,
@@ -110,12 +109,12 @@ var _ = Describe("QuickStart", func() {
 					ArtifactFolder:         e2eCtx.Settings.ArtifactFolder,
 					SkipCleanup:            e2eCtx.Settings.SkipCleanup,
 					PostNamespaceCreated:   e2eCtx.DefaultPostNamespaceCreated(),
-					InfrastructureProvider: ptr.To("incus:v0.88.99"),
+					InfrastructureProvider: new("incus:v0.88.99"),
 
-					Flavor:                   ptr.To(shared.FlavorDefault),
-					ControlPlaneMachineCount: ptr.To[int64](3),
-					WorkerMachineCount:       ptr.To[int64](1),
-					ClusterName:              ptr.To(fmt.Sprintf("capn-kind-unprivileged-%s", util.RandomString(4))),
+					Flavor:                   new(shared.FlavorDefault),
+					ControlPlaneMachineCount: new(int64(3)),
+					WorkerMachineCount:       new(int64(1)),
+					ClusterName:              new(fmt.Sprintf("capn-kind-unprivileged-%s", util.RandomString(4))),
 
 					ControlPlaneWaiters: clusterctl.ControlPlaneWaiters{
 						WaitForControlPlaneMachinesReady: applyDefaultKindCNI,

--- a/test/e2e/suites/e2e/quick_start_kube_vip_test.go
+++ b/test/e2e/suites/e2e/quick_start_kube_vip_test.go
@@ -10,7 +10,6 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 
 	"github.com/lxc/cluster-api-provider-incus/internal/lxc"
-	"github.com/lxc/cluster-api-provider-incus/internal/ptr"
 	"github.com/lxc/cluster-api-provider-incus/test/e2e/shared"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -60,12 +59,12 @@ var _ = Describe("QuickStart", func() {
 					ArtifactFolder:         e2eCtx.Settings.ArtifactFolder,
 					SkipCleanup:            e2eCtx.Settings.SkipCleanup,
 					PostNamespaceCreated:   e2eCtx.DefaultPostNamespaceCreated(),
-					InfrastructureProvider: ptr.To("incus:v0.88.99"),
+					InfrastructureProvider: new("incus:v0.88.99"),
 
-					Flavor:                   ptr.To(shared.FlavorDefault),
-					ControlPlaneMachineCount: ptr.To[int64](3),
-					WorkerMachineCount:       ptr.To[int64](1),
-					ClusterName:              ptr.To(fmt.Sprintf("capn-kube-vip-%s", util.RandomString(4))),
+					Flavor:                   new(shared.FlavorDefault),
+					ControlPlaneMachineCount: new(int64(3)),
+					WorkerMachineCount:       new(int64(1)),
+					ClusterName:              new(fmt.Sprintf("capn-kube-vip-%s", util.RandomString(4))),
 				}
 			})
 		})
@@ -79,12 +78,12 @@ var _ = Describe("QuickStart", func() {
 					ArtifactFolder:         e2eCtx.Settings.ArtifactFolder,
 					SkipCleanup:            e2eCtx.Settings.SkipCleanup,
 					PostNamespaceCreated:   e2eCtx.DefaultPostNamespaceCreated(),
-					InfrastructureProvider: ptr.To("incus:v0.88.99"),
+					InfrastructureProvider: new("incus:v0.88.99"),
 
-					Flavor:                   ptr.To(shared.FlavorDefault),
-					ControlPlaneMachineCount: ptr.To[int64](3),
-					WorkerMachineCount:       ptr.To[int64](1),
-					ClusterName:              ptr.To(fmt.Sprintf("capn-kube-vip-unprivileged-%s", util.RandomString(4))),
+					Flavor:                   new(shared.FlavorDefault),
+					ControlPlaneMachineCount: new(int64(3)),
+					WorkerMachineCount:       new(int64(1)),
+					ClusterName:              new(fmt.Sprintf("capn-kube-vip-unprivileged-%s", util.RandomString(4))),
 
 					ClusterctlVariables: map[string]string{"PRIVILEGED": "false"},
 				}

--- a/test/e2e/suites/e2e/quick_start_kvm_test.go
+++ b/test/e2e/suites/e2e/quick_start_kvm_test.go
@@ -11,7 +11,6 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 
 	"github.com/lxc/cluster-api-provider-incus/internal/lxc"
-	"github.com/lxc/cluster-api-provider-incus/internal/ptr"
 	"github.com/lxc/cluster-api-provider-incus/test/e2e/shared"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -48,12 +47,12 @@ var _ = Describe("QuickStart", func() {
 					ArtifactFolder:         e2eCtx.Settings.ArtifactFolder,
 					SkipCleanup:            e2eCtx.Settings.SkipCleanup,
 					PostNamespaceCreated:   e2eCtx.DefaultPostNamespaceCreated(),
-					InfrastructureProvider: ptr.To("incus:v0.88.99"),
+					InfrastructureProvider: new("incus:v0.88.99"),
 
-					Flavor:                   ptr.To(shared.FlavorDefault),
-					ControlPlaneMachineCount: ptr.To[int64](1),
-					WorkerMachineCount:       ptr.To[int64](1),
-					ClusterName:              ptr.To(fmt.Sprintf("capn-kvm-%s", util.RandomString(4))),
+					Flavor:                   new(shared.FlavorDefault),
+					ControlPlaneMachineCount: new(int64(1)),
+					WorkerMachineCount:       new(int64(1)),
+					ClusterName:              new(fmt.Sprintf("capn-kvm-%s", util.RandomString(4))),
 				}
 			})
 		})
@@ -67,12 +66,12 @@ var _ = Describe("QuickStart", func() {
 					ArtifactFolder:         e2eCtx.Settings.ArtifactFolder,
 					SkipCleanup:            e2eCtx.Settings.SkipCleanup,
 					PostNamespaceCreated:   e2eCtx.DefaultPostNamespaceCreated(),
-					InfrastructureProvider: ptr.To("incus:v0.88.99"),
+					InfrastructureProvider: new("incus:v0.88.99"),
 
-					Flavor:                   ptr.To(shared.FlavorDefault),
-					ControlPlaneMachineCount: ptr.To[int64](1),
-					WorkerMachineCount:       ptr.To[int64](1),
-					ClusterName:              ptr.To(fmt.Sprintf("capn-kvm-unprivileged-%s", util.RandomString(4))),
+					Flavor:                   new(shared.FlavorDefault),
+					ControlPlaneMachineCount: new(int64(1)),
+					WorkerMachineCount:       new(int64(1)),
+					ClusterName:              new(fmt.Sprintf("capn-kvm-unprivileged-%s", util.RandomString(4))),
 
 					ClusterctlVariables: map[string]string{"PRIVILEGED": "false"},
 				}

--- a/test/e2e/suites/e2e/quick_start_oci_test.go
+++ b/test/e2e/suites/e2e/quick_start_oci_test.go
@@ -10,7 +10,6 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 
 	"github.com/lxc/cluster-api-provider-incus/internal/lxc"
-	"github.com/lxc/cluster-api-provider-incus/internal/ptr"
 	"github.com/lxc/cluster-api-provider-incus/internal/utils"
 	"github.com/lxc/cluster-api-provider-incus/test/e2e/shared"
 
@@ -43,12 +42,12 @@ var _ = Describe("QuickStart", func() {
 				ArtifactFolder:         e2eCtx.Settings.ArtifactFolder,
 				SkipCleanup:            e2eCtx.Settings.SkipCleanup,
 				PostNamespaceCreated:   e2eCtx.DefaultPostNamespaceCreated(),
-				InfrastructureProvider: ptr.To("incus:v0.88.99"),
+				InfrastructureProvider: new("incus:v0.88.99"),
 
-				Flavor:                   ptr.To(shared.FlavorDefault),
-				ControlPlaneMachineCount: ptr.To[int64](3),
-				WorkerMachineCount:       ptr.To[int64](1),
-				ClusterName:              ptr.To(fmt.Sprintf("capn-oci-%s", util.RandomString(4))),
+				Flavor:                   new(shared.FlavorDefault),
+				ControlPlaneMachineCount: new(int64(3)),
+				WorkerMachineCount:       new(int64(1)),
+				ClusterName:              new(fmt.Sprintf("capn-oci-%s", util.RandomString(4))),
 			}
 		})
 	})

--- a/test/e2e/suites/e2e/quick_start_ovn_test.go
+++ b/test/e2e/suites/e2e/quick_start_ovn_test.go
@@ -10,7 +10,6 @@ import (
 	"sigs.k8s.io/cluster-api/util"
 
 	"github.com/lxc/cluster-api-provider-incus/internal/lxc"
-	"github.com/lxc/cluster-api-provider-incus/internal/ptr"
 	"github.com/lxc/cluster-api-provider-incus/internal/utils"
 	"github.com/lxc/cluster-api-provider-incus/test/e2e/shared"
 
@@ -59,12 +58,12 @@ var _ = Describe("QuickStart", func() {
 				ArtifactFolder:         e2eCtx.Settings.ArtifactFolder,
 				SkipCleanup:            e2eCtx.Settings.SkipCleanup,
 				PostNamespaceCreated:   e2eCtx.DefaultPostNamespaceCreated(),
-				InfrastructureProvider: ptr.To("incus:v0.88.99"),
+				InfrastructureProvider: new("incus:v0.88.99"),
 
-				Flavor:                   ptr.To(shared.FlavorDefault),
-				ControlPlaneMachineCount: ptr.To[int64](3),
-				WorkerMachineCount:       ptr.To[int64](1),
-				ClusterName:              ptr.To(fmt.Sprintf("capn-ovn-%s", util.RandomString(4))),
+				Flavor:                   new(shared.FlavorDefault),
+				ControlPlaneMachineCount: new(int64(3)),
+				WorkerMachineCount:       new(int64(1)),
+				ClusterName:              new(fmt.Sprintf("capn-ovn-%s", util.RandomString(4))),
 			}
 		})
 	})

--- a/test/e2e/suites/e2e/quick_start_ubuntu_test.go
+++ b/test/e2e/suites/e2e/quick_start_ubuntu_test.go
@@ -9,7 +9,6 @@ import (
 	"sigs.k8s.io/cluster-api/test/e2e"
 	"sigs.k8s.io/cluster-api/util"
 
-	"github.com/lxc/cluster-api-provider-incus/internal/ptr"
 	"github.com/lxc/cluster-api-provider-incus/test/e2e/shared"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -33,12 +32,12 @@ var _ = Describe("QuickStart", func() {
 					ArtifactFolder:         e2eCtx.Settings.ArtifactFolder,
 					SkipCleanup:            e2eCtx.Settings.SkipCleanup,
 					PostNamespaceCreated:   e2eCtx.DefaultPostNamespaceCreated(),
-					InfrastructureProvider: ptr.To("incus:v0.88.99"),
+					InfrastructureProvider: new("incus:v0.88.99"),
 
-					Flavor:                   ptr.To(shared.FlavorDefault),
-					ControlPlaneMachineCount: ptr.To[int64](1),
-					WorkerMachineCount:       ptr.To[int64](1),
-					ClusterName:              ptr.To(fmt.Sprintf("capn-ubuntu-%s", util.RandomString(4))),
+					Flavor:                   new(shared.FlavorDefault),
+					ControlPlaneMachineCount: new(int64(1)),
+					WorkerMachineCount:       new(int64(1)),
+					ClusterName:              new(fmt.Sprintf("capn-ubuntu-%s", util.RandomString(4))),
 				}
 			})
 		})
@@ -52,12 +51,12 @@ var _ = Describe("QuickStart", func() {
 					ArtifactFolder:         e2eCtx.Settings.ArtifactFolder,
 					SkipCleanup:            e2eCtx.Settings.SkipCleanup,
 					PostNamespaceCreated:   e2eCtx.DefaultPostNamespaceCreated(),
-					InfrastructureProvider: ptr.To("incus:v0.88.99"),
+					InfrastructureProvider: new("incus:v0.88.99"),
 
-					Flavor:                   ptr.To(shared.FlavorDefault),
-					ControlPlaneMachineCount: ptr.To[int64](1),
-					WorkerMachineCount:       ptr.To[int64](1),
-					ClusterName:              ptr.To(fmt.Sprintf("capn-ubuntu-unprivileged-%s", util.RandomString(4))),
+					Flavor:                   new(shared.FlavorDefault),
+					ControlPlaneMachineCount: new(int64(1)),
+					WorkerMachineCount:       new(int64(1)),
+					ClusterName:              new(fmt.Sprintf("capn-ubuntu-unprivileged-%s", util.RandomString(4))),
 
 					ClusterctlVariables: map[string]string{"PRIVILEGED": "false"},
 				}

--- a/test/e2e/suites/e2e/self_hosted_test.go
+++ b/test/e2e/suites/e2e/self_hosted_test.go
@@ -15,7 +15,6 @@ import (
 	"sigs.k8s.io/cluster-api/test/framework"
 
 	"github.com/lxc/cluster-api-provider-incus/internal/lxc"
-	"github.com/lxc/cluster-api-provider-incus/internal/ptr"
 	"github.com/lxc/cluster-api-provider-incus/test/e2e/shared"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -75,12 +74,12 @@ var _ = Describe("SelfHosted", func() {
 			BootstrapClusterProxy:  e2eCtx.Environment.BootstrapClusterProxy,
 			ArtifactFolder:         e2eCtx.Settings.ArtifactFolder,
 			SkipCleanup:            e2eCtx.Settings.SkipCleanup,
-			InfrastructureProvider: ptr.To("incus:v0.88.99"),
+			InfrastructureProvider: new("incus:v0.88.99"),
 
 			Flavor:                   shared.FlavorDefault,
 			SkipUpgrade:              true,
-			ControlPlaneMachineCount: ptr.To[int64](1),
-			WorkerMachineCount:       ptr.To[int64](1),
+			ControlPlaneMachineCount: new(int64(1)),
+			WorkerMachineCount:       new(int64(1)),
 
 			// We hijack PostNamespaceCreated to allow pre-loading images into the workload cluster
 			// This is required for the CAPN provider e2e image, which is not published

--- a/test/e2e/suites/e2e/upgrade_test.go
+++ b/test/e2e/suites/e2e/upgrade_test.go
@@ -7,7 +7,6 @@ import (
 
 	"sigs.k8s.io/cluster-api/test/e2e"
 
-	"github.com/lxc/cluster-api-provider-incus/internal/ptr"
 	"github.com/lxc/cluster-api-provider-incus/test/e2e/shared"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -23,11 +22,11 @@ var _ = Describe("ClusterUpgrade", func() {
 				ArtifactFolder:         e2eCtx.Settings.ArtifactFolder,
 				SkipCleanup:            e2eCtx.Settings.SkipCleanup,
 				PostNamespaceCreated:   e2eCtx.DefaultPostNamespaceCreated(),
-				InfrastructureProvider: ptr.To("incus:v0.88.99"),
+				InfrastructureProvider: new("incus:v0.88.99"),
 
-				Flavor:                   ptr.To(shared.FlavorDefault),
-				ControlPlaneMachineCount: ptr.To[int64](1),
-				WorkerMachineCount:       ptr.To[int64](1),
+				Flavor:                   new(shared.FlavorDefault),
+				ControlPlaneMachineCount: new(int64(1)),
+				WorkerMachineCount:       new(int64(1)),
 
 				SkipConformanceTests: true,
 			}
@@ -42,11 +41,11 @@ var _ = Describe("ClusterUpgrade", func() {
 				ArtifactFolder:         e2eCtx.Settings.ArtifactFolder,
 				SkipCleanup:            e2eCtx.Settings.SkipCleanup,
 				PostNamespaceCreated:   e2eCtx.DefaultPostNamespaceCreated(),
-				InfrastructureProvider: ptr.To("incus:v0.88.99"),
+				InfrastructureProvider: new("incus:v0.88.99"),
 
-				Flavor:                   ptr.To(shared.FlavorDefault),
-				ControlPlaneMachineCount: ptr.To[int64](3),
-				WorkerMachineCount:       ptr.To[int64](2),
+				Flavor:                   new(shared.FlavorDefault),
+				ControlPlaneMachineCount: new(int64(3)),
+				WorkerMachineCount:       new(int64(2)),
 
 				SkipConformanceTests: true,
 			}


### PR DESCRIPTION
### Summary

chore, use `new(expr)` allowed in Go 1.26 instead of the `ptr.To`